### PR TITLE
supporting removed dependencies

### DIFF
--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -109,6 +109,10 @@ func Run(params RunParams) error {
 					}
 
 					for _, dep := range createPR.Dependencies {
+						if dep.Version == nil {
+							// dependency version nil due to it being removed
+							continue
+						}
 						ignore := model.Condition{
 							DependencyName:     dep.Name,
 							VersionRequirement: fmt.Sprintf(">%v", *dep.Version),

--- a/internal/infra/run_test.go
+++ b/internal/infra/run_test.go
@@ -5,12 +5,76 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"reflect"
 	"testing"
 
 	"github.com/dependabot/cli/internal/model"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 )
+
+func Test_generateIgnoreConditions(t *testing.T) {
+	const (
+		outputFileName = "test_output"
+		dependencyName = "dep1"
+		version        = "1.0.0"
+	)
+
+	t.Run("generates ignore conditions", func(t *testing.T) {
+		runParams := &RunParams{
+			Output: outputFileName,
+		}
+		v := "1.0.0"
+		actual := &model.Scenario{
+			Output: []model.Output{{
+				Type: "create_pull_request",
+				Expect: model.UpdateWrapper{Data: model.CreatePullRequest{
+					Dependencies: []model.Dependency{{
+						Name:    dependencyName,
+						Version: &v,
+					}},
+				}},
+			}},
+		}
+		if err := generateIgnoreConditions(runParams, actual); err != nil {
+			t.Fatal(err)
+		}
+		if len(actual.Input.Job.IgnoreConditions) != 1 {
+			t.Error("expected 1 ignore condition to be generated, got", len(actual.Input.Job.IgnoreConditions))
+		}
+		ignore := actual.Input.Job.IgnoreConditions[0]
+		if reflect.DeepEqual(ignore, &model.Condition{
+			DependencyName:     dependencyName,
+			Source:             outputFileName,
+			VersionRequirement: ">" + version,
+		}) {
+			t.Error("unexpected ignore condition", ignore)
+		}
+	})
+
+	t.Run("handles removed dependency", func(t *testing.T) {
+		runParams := &RunParams{
+			Output: outputFileName,
+		}
+		actual := &model.Scenario{
+			Output: []model.Output{{
+				Type: "create_pull_request",
+				Expect: model.UpdateWrapper{Data: model.CreatePullRequest{
+					Dependencies: []model.Dependency{{
+						Name:    dependencyName,
+						Removed: true,
+					}},
+				}},
+			}},
+		}
+		if err := generateIgnoreConditions(runParams, actual); err != nil {
+			t.Fatal(err)
+		}
+		if len(actual.Input.Job.IgnoreConditions) != 0 {
+			t.Error("expected 0 ignore condition to be generated, got", len(actual.Input.Job.IgnoreConditions))
+		}
+	})
+}
 
 func TestRun(t *testing.T) {
 	if testing.Short() {

--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -64,6 +64,7 @@ type Dependency struct {
 	PreviousVersion      string         `json:"previous-version,omitempty" yaml:"previous-version,omitempty"`
 	Requirements         []Requirement  `json:"requirements"`
 	Version              *string        `json:"version" yaml:"version"`
+	Removed              bool           `json:"removed,omitempty" yaml:"removed,omitempty"`
 }
 
 type Requirement struct {


### PR DESCRIPTION
During a Dependabot update, it's possible a dependency is removed. 

The CLI wasn't handling that case well when generating ignore conditions for a test, and getting a null pointer exception when doing `*dep.Version`. 

Also this adds the `removed` boolean on the dependency, so tests will assert outputs properly.