### PR TITLE
Partial migration to `moby/moby`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/docker/cli v20.10.18+incompatible
 	github.com/docker/docker v20.10.18+incompatible
+	github.com/moby/moby v20.10.18+incompatible
 	github.com/moby/sys/signal v0.7.0
 	github.com/sergi/go-diff v1.2.0
 	github.com/spf13/cobra v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/moby/moby v20.10.18+incompatible h1:aAQ5lDb+SDrhVDnoMbR3kSzswd+41X34pex8VRJXvHg=
+github.com/moby/moby v20.10.18+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/moby/sys/signal v0.7.0 h1:25RW3d5TnQEoKvRbEKUGay6DCQ46IxAVTT9CUMgmsSI=
 github.com/moby/sys/signal v0.7.0/go.mod h1:GQ6ObYZfqacOwTtlXvcmh9A26dVRul/hbOZn88Kg8Tg=
 github.com/moby/term v0.0.0-20220808134915-39b0c02b01ae h1:O4SWKdcHVCvYqyDV+9CJA1fcDN2L11Bule0iFy3YlAI=

--- a/internal/infra/network.go
+++ b/internal/infra/network.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/namesgenerator"
+	"github.com/moby/moby/client"
+	"github.com/moby/moby/pkg/namesgenerator"
 )
 
 type Networks struct {

--- a/internal/infra/proxy.go
+++ b/internal/infra/proxy.go
@@ -14,9 +14,9 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
-	"github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/namesgenerator"
-	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/moby/moby/client"
+	"github.com/moby/moby/pkg/namesgenerator"
+	"github.com/moby/moby/pkg/stdcopy"
 )
 
 const proxyCertPath = "/usr/local/share/ca-certificates/custom-ca-cert.crt"

--- a/internal/infra/proxy_test.go
+++ b/internal/infra/proxy_test.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/namesgenerator"
+	"github.com/moby/moby/client"
+	"github.com/moby/moby/pkg/namesgenerator"
 )
 
 func TestSeed(t *testing.T) {

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/dependabot/cli/internal/model"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
+	"github.com/moby/moby/client"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/infra/run_test.go
+++ b/internal/infra/run_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/dependabot/cli/internal/model"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
+	"github.com/moby/moby/client"
 )
 
 func Test_generateIgnoreConditions(t *testing.T) {

--- a/internal/infra/tty.go
+++ b/internal/infra/tty.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
+	"github.com/moby/moby/client"
 	"github.com/moby/sys/signal"
 )
 

--- a/internal/infra/updater.go
+++ b/internal/infra/updater.go
@@ -15,8 +15,8 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
-	"github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/moby/moby/client"
+	"github.com/moby/moby/pkg/stdcopy"
 )
 
 const jobID = "cli"


### PR DESCRIPTION
`docker/docker` repo has moved to `moby/moby`: https://github.com/docker/docker

However, when I tried switching all references to `moby/moby`, I ran into compile errors about types of `moby/moby` not matching `docker/docker`. I have a hunch another underlying dependency hasn't updated to `moby/moby`, but I didn't actually look into why... just limited the scope of the PR for now as this isn't urgent. Later we can dig into it more at some point.