### PR TITLE
allow modifying /etc/hosts on the proxy for testing

### DIFF
--- a/cmd/dependabot/internal/cmd/root.go
+++ b/cmd/dependabot/internal/cmd/root.go
@@ -14,6 +14,7 @@ var (
 	file       string
 	cache      string
 	debugging  bool
+	extraHosts []string
 	output     string
 	pullImages bool
 	volumes    []string

--- a/cmd/dependabot/internal/cmd/test.go
+++ b/cmd/dependabot/internal/cmd/test.go
@@ -41,6 +41,7 @@ var testCmd = &cobra.Command{
 			Creds:      scenario.Input.Credentials,
 			Debug:      debugging,
 			Expected:   scenario.Output,
+			ExtraHosts: extraHosts,
 			Job:        &scenario.Input.Job,
 			Output:     output,
 			PullImages: pullImages,
@@ -83,5 +84,6 @@ func init() {
 	testCmd.Flags().BoolVar(&pullImages, "pull", true, "pull the image if it isn't present")
 	testCmd.Flags().BoolVar(&debugging, "debug", false, "run an interactive shell inside the updater")
 	testCmd.Flags().StringArrayVarP(&volumes, "volume", "v", nil, "mount volumes in Docker")
+	testCmd.Flags().StringArrayVar(&extraHosts, "extra-hosts", nil, "Docker extra hosts setting on the proxy")
 	testCmd.Flags().DurationVarP(&timeout, "timeout", "t", 0, "max time to run an update")
 }

--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -115,6 +115,7 @@ var updateCmd = &cobra.Command{
 			Creds:      input.Credentials,
 			Debug:      debugging,
 			Expected:   nil, // update subcommand doesn't use expectations
+			ExtraHosts: extraHosts,
 			Job:        &input.Job,
 			Output:     output,
 			PullImages: pullImages,
@@ -192,6 +193,7 @@ func init() {
 	updateCmd.Flags().BoolVar(&pullImages, "pull", true, "pull the image if it isn't present")
 	updateCmd.Flags().BoolVar(&debugging, "debug", false, "run an interactive shell inside the updater")
 	updateCmd.Flags().StringArrayVarP(&volumes, "volume", "v", nil, "mount volumes in Docker")
+	updateCmd.Flags().StringArrayVar(&extraHosts, "extra-hosts", nil, "Docker extra hosts setting on the proxy")
 	updateCmd.Flags().DurationVarP(&timeout, "timeout", "t", 0, "max time to run an update")
 	updateCmd.Flags().IntVar(&inputServerPort, "input-port", 0, "port to use for securely passing input to the updater")
 }

--- a/internal/infra/proxy.go
+++ b/internal/infra/proxy.go
@@ -70,6 +70,7 @@ func NewProxy(ctx context.Context, cli *client.Client, params *RunParams, nets .
 			"host.docker.internal:host-gateway",
 		},
 	}
+	hostCfg.ExtraHosts = append(hostCfg.ExtraHosts, params.ExtraHosts...)
 	if params.CacheDir != "" {
 		_ = os.MkdirAll(params.CacheDir, 0744)
 		cacheDir, _ := filepath.Abs(params.CacheDir)

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -41,6 +41,8 @@ type RunParams struct {
 	Timeout time.Duration
 	// TempDir is the path to use as the temporary directory.
 	TempDir string
+	// ExtraHosts adds /etc/hosts entries to the proxy for testing.
+	ExtraHosts []string
 }
 
 func Run(params RunParams) error {


### PR DESCRIPTION
This is to support testing firewalled GHES runners.

I first tried to use UFW to block access to a registry like this:

```
sudo ufw default allow incoming
for IP in $(dig +short registry.npmjs.org)
do
 sudo ufw deny out from any to $IP port 443
done

sudo ufw enable
```

Tested with curl this worked, but as soon as I ran `dependabot` it stopped working and calls to registry.npmjs.org succeeded. After some research, it seems Docker uses iptables for networking and prevents UFW from affecting it. I tried [this](https://github.com/chaifeng/ufw-docker) as well and it didn't seem to work.

So, thinking about it some more, UFW deny or iptables DROP actually just drops the packets sent to make it look to an attacker like there's no host there at all. This is exactly the same as if you try to contact an IP with no host, e.g. a 192.168.0.0/16 address in actions.

Thus this solution was born. 
