### PR TITLE
add debug environment variable when debugging

### DIFF
--- a/internal/infra/updater.go
+++ b/internal/infra/updater.go
@@ -178,7 +178,7 @@ func (u *Updater) RunShell(ctx context.Context, proxyURL string, apiPort int) er
 		AttachStderr: true,
 		Tty:          true,
 		User:         dependabot,
-		Env:          userEnv(proxyURL, apiPort),
+		Env:          append(userEnv(proxyURL, apiPort), "DEBUG=1"),
 		Cmd:          []string{"/bin/bash"},
 	})
 	if err != nil {


### PR DESCRIPTION
Adds the environment variable "DEBUG=1" when the `--debug` flag is passed, which will cause the updater to require the "debug" gem allowing for interactive debugging.

Related: https://github.com/dependabot/dependabot-core/pull/5763