### PR TITLE
easier and safer to mount the repo directory

### DIFF
--- a/internal/infra/updater_test.go
+++ b/internal/infra/updater_test.go
@@ -1,0 +1,50 @@
+package infra
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func Test_mountOptions(t *testing.T) {
+	wd, _ := os.Getwd()
+	tests := []struct {
+		input            string
+		expectedLocal    string
+		expectedRemote   string
+		expectedReadOnly bool
+		expectedErr      error
+	}{
+		{
+			input:       "",
+			expectedErr: ErrInvalidVolume,
+		}, {
+			input:          "local:remote",
+			expectedLocal:  filepath.Join(wd, "local"),
+			expectedRemote: "remote",
+		}, {
+			input:            "local:remote:ro",
+			expectedLocal:    filepath.Join(wd, "local"),
+			expectedRemote:   "remote",
+			expectedReadOnly: true,
+		}, {
+			input:            ".:remote:ro",
+			expectedLocal:    wd,
+			expectedRemote:   "remote",
+			expectedReadOnly: true,
+		}, {
+			input:       "local:remote:ro:hi",
+			expectedErr: ErrInvalidVolume,
+		}, {
+			input:       "local:remote:wo",
+			expectedErr: ErrInvalidVolume,
+		},
+	}
+
+	for _, test := range tests {
+		local, remote, readOnly, err := mountOptions(test.input)
+		if local != test.expectedLocal || remote != test.expectedRemote || readOnly != test.expectedReadOnly || err != test.expectedErr {
+			t.Errorf("For input '%v' got '%v' '%v' '%v' '%v'", test.input, local, remote, readOnly, err)
+		}
+	}
+}


### PR DESCRIPTION
I realized in #13 we can mount a local repo to the container path  using`-v "$(pwd)":/home/dependabot/dependabot-updater/repo` to avoid the fetch step.

In this PR I do two things to make this better: 

- Automatically expand local paths that are not absolute. This makes it slightly easier to mount with: `-v ".:/home/dependabot/dependabot-updater/repo`. This is nice because it's easy to forget the volume has to be absolute. The CLI already does this in several places for other flags.
- Support the "read only" volume flag, which Docker supports, which looks like this: `-v ".:/home/dependabot/dependabot-updater/repo:ro`. This is nice in case the updater messes with the repo it will error rather than change the contents under test.