### PR TITLE
Enable Dependabot updating the GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/" # Location of package manifests
     schedule:


### PR DESCRIPTION
We're getting deprecation warnings that some of our actions make deprecated calls: https://github.com/dependabot/cli/actions/runs/3239871126/jobs/5309789625#step:3:17

This was already [fixed upstream](https://github.com/actions/setup-go/pull/273), and since we pin to only the floating tag I suspect they simply haven't tagged a new release... once they do we should be fine.

However, it made me realize that previously Dependabot wasn't watching for outdated actions.