### PR TITLE
handle SIGINT better during the creation process

### DIFF
--- a/internal/infra/updater.go
+++ b/internal/infra/updater.go
@@ -111,16 +111,17 @@ func NewUpdater(ctx context.Context, cli *client.Client, net *Networks, params *
 		return nil, fmt.Errorf("failed to create updater container: %w", err)
 	}
 
-	if err := cli.ContainerStart(ctx, updaterContainer.ID, types.ContainerStartOptions{}); err != nil {
-		return nil, fmt.Errorf("failed to start updater container: %w", err)
-	}
-
 	updater := &Updater{
 		cli:         cli,
 		containerID: updaterContainer.ID,
 		outputDir:   outputDir,
 		RepoDir:     repoDir,
 		inputPath:   inputPath,
+	}
+
+	if err := cli.ContainerStart(ctx, updaterContainer.ID, types.ContainerStartOptions{}); err != nil {
+		updater.Close()
+		return nil, fmt.Errorf("failed to start updater container: %w", err)
 	}
 
 	return updater, nil


### PR DESCRIPTION
I noticed I have a lot of containers sitting around from previous runs. I think this is due to hitting CTL-C during startup. 

This PR adds calls to `Close` which does the cleanup whenever an error occurs after creation of the container within the constructor. Trying this locally, it seems to be handling things much better.
