### PR TITLE
fix replaces base boolean coming into the job as a string

### DIFF
--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -2,24 +2,24 @@ package model
 
 // Job is the data that is passed to the updater.
 type Job struct {
-	PackageManager             string              `json:"package-manager" yaml:"package-manager"`
-	AllowedUpdates             []Allowed           `json:"allowed-updates" yaml:"allowed-updates,omitempty"`
-	Dependencies               []string            `json:"dependencies" yaml:"dependencies,omitempty"`
-	ExistingPullRequests       [][]ExistingPR      `json:"existing-pull-requests" yaml:"existing-pull-requests,omitempty"`
-	Experiments                Experiment          `json:"experiments" yaml:"experiments,omitempty"`
-	IgnoreConditions           []Condition         `json:"ignore-conditions" yaml:"ignore-conditions,omitempty"`
-	LockfileOnly               bool                `json:"lockfile-only" yaml:"lockfile-only,omitempty"`
-	RequirementsUpdateStrategy *string             `json:"requirements-update-strategy" yaml:"requirements-update-strategy,omitempty"`
-	SecurityAdvisories         []Advisory          `json:"security-advisories" yaml:"security-advisories,omitempty"`
-	SecurityUpdatesOnly        bool                `json:"security-updates-only" yaml:"security-updates-only,omitempty"`
-	Source                     Source              `json:"source" yaml:"source"`
-	UpdateSubdependencies      bool                `json:"update-subdependencies" yaml:"update-subdependencies,omitempty"`
-	UpdatingAPullRequest       bool                `json:"updating-a-pull-request" yaml:"updating-a-pull-request,omitempty"`
-	VendorDependencies         bool                `json:"vendor-dependencies" yaml:"vendor-dependencies,omitempty"`
-	RejectExternalCode         bool                `json:"reject-external-code" yaml:"reject-external-code,omitempty"`
-	CommitMessageOptions       *CommitOptions      `json:"commit-message-options" yaml:"commit-message-options,omitempty"`
-	CredentialsMetadata        []map[string]string `json:"credentials-metadata" yaml:"credentials-metadata,omitempty"`
-	MaxUpdaterRunTime          int                 `json:"max-updater-run-time" yaml:"max-updater-run-time,omitempty"`
+	PackageManager             string           `json:"package-manager" yaml:"package-manager"`
+	AllowedUpdates             []Allowed        `json:"allowed-updates" yaml:"allowed-updates,omitempty"`
+	Dependencies               []string         `json:"dependencies" yaml:"dependencies,omitempty"`
+	ExistingPullRequests       [][]ExistingPR   `json:"existing-pull-requests" yaml:"existing-pull-requests,omitempty"`
+	Experiments                Experiment       `json:"experiments" yaml:"experiments,omitempty"`
+	IgnoreConditions           []Condition      `json:"ignore-conditions" yaml:"ignore-conditions,omitempty"`
+	LockfileOnly               bool             `json:"lockfile-only" yaml:"lockfile-only,omitempty"`
+	RequirementsUpdateStrategy *string          `json:"requirements-update-strategy" yaml:"requirements-update-strategy,omitempty"`
+	SecurityAdvisories         []Advisory       `json:"security-advisories" yaml:"security-advisories,omitempty"`
+	SecurityUpdatesOnly        bool             `json:"security-updates-only" yaml:"security-updates-only,omitempty"`
+	Source                     Source           `json:"source" yaml:"source"`
+	UpdateSubdependencies      bool             `json:"update-subdependencies" yaml:"update-subdependencies,omitempty"`
+	UpdatingAPullRequest       bool             `json:"updating-a-pull-request" yaml:"updating-a-pull-request,omitempty"`
+	VendorDependencies         bool             `json:"vendor-dependencies" yaml:"vendor-dependencies,omitempty"`
+	RejectExternalCode         bool             `json:"reject-external-code" yaml:"reject-external-code,omitempty"`
+	CommitMessageOptions       *CommitOptions   `json:"commit-message-options" yaml:"commit-message-options,omitempty"`
+	CredentialsMetadata        []map[string]any `json:"credentials-metadata" yaml:"credentials-metadata,omitempty"`
+	MaxUpdaterRunTime          int              `json:"max-updater-run-time" yaml:"max-updater-run-time,omitempty"`
 }
 
 // Source is a reference to some source code


### PR DESCRIPTION
A test I wrote for `replaces-base` was failing. It turns out the value was coming in to the job as a string due to the model in the CLI being wrong.

This sets that straight, I've verified this is the correct behavior.