### PR TITLE
create credential conveniences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 tmp
 testdata/caches
 cache
+out.yaml

--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -180,6 +180,7 @@ func processInput(input *model.Input) {
 		}
 	}
 	if token != "" && !isGitSourceInCreds {
+		log.Println("Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials")
 		input.Credentials = append(input.Credentials, model.Credential{
 			"type":     "git_source",
 			"host":     "github.com",
@@ -199,6 +200,7 @@ func processInput(input *model.Input) {
 	// which is what happens in production. This way the user doesn't have to
 	// specify credentials-metadata in the scenario file unless they want to.
 	if len(input.Job.CredentialsMetadata) == 0 {
+		log.Println("Adding missing credentials-metadata into job definition")
 		for _, credential := range input.Credentials {
 			entry := map[string]any{
 				"type": credential["type"],

--- a/cmd/dependabot/internal/cmd/update_test.go
+++ b/cmd/dependabot/internal/cmd/update_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/dependabot/cli/internal/model"
+)
+
+func Test_processInput(t *testing.T) {
+	t.Run("initializes some fields", func(t *testing.T) {
+		var input model.Input
+		processInput(&input)
+
+		if input.Job.ExistingPullRequests == nil {
+			t.Error("expected existing pull requests to be initialized")
+		}
+		if input.Job.IgnoreConditions == nil {
+			t.Error("expected ignore conditions to be initialized")
+		}
+		if input.Job.SecurityAdvisories == nil {
+			t.Error("expected security advisories to be initialized")
+		}
+	})
+
+	t.Run("injects environment variables", func(t *testing.T) {
+		var input model.Input
+		input.Credentials = []model.Credential{{
+			"type":     "any",
+			"host":     "host",
+			"url":      "url",
+			"username": "$ENV1",
+			"pass":     "$ENV2",
+		}}
+		os.Setenv("ENV1", "value1")
+		os.Setenv("ENV2", "value2")
+		os.Setenv("LOCAL_GITHUB_ACCESS_TOKEN", "") // fixes test while running locally
+
+		processInput(&input)
+
+		if input.Credentials[0]["username"] != "value1" {
+			t.Error("expected username to be injected")
+		}
+		if input.Credentials[0]["pass"] != "value2" {
+			t.Error("expected pass to be injected")
+		}
+		if !reflect.DeepEqual(input.Job.CredentialsMetadata, []model.Credential{{
+			"type": "any",
+			"host": "host",
+			"url":  "url",
+		}}) {
+			t.Error("expected credentials metadata to be to", input.Job.CredentialsMetadata)
+		}
+	})
+
+	t.Run("adds git_source to credentials", func(t *testing.T) {
+		var input model.Input
+		os.Setenv("LOCAL_GITHUB_ACCESS_TOKEN", "token")
+		// Adding a dummy metadata to test the inner if
+		input.Job.CredentialsMetadata = []model.Credential{{}}
+
+		processInput(&input)
+
+		if len(input.Credentials) != 1 {
+			t.Fatal("expected credentials to be added")
+		}
+		if !reflect.DeepEqual(input.Credentials[0], model.Credential{
+			"type":     "git_source",
+			"host":     "github.com",
+			"username": "x-access-token",
+			"password": "token",
+		}) {
+			t.Error("expected credentials to be added")
+		}
+		if !reflect.DeepEqual(input.Job.CredentialsMetadata[1], model.Credential{
+			"type": "git_source",
+			"host": "github.com",
+		}) {
+			t.Error("expected credentials metadata to be added")
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.8.0 // indirect
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
-	golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359 // indirect
+	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/time v0.0.0-20220609170525-579cf78fd858 // indirect
 	gotest.tools/v3 v3.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,9 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359 h1:2B5p2L5IfGiD7+b9BOoRMC6DgObAVZV+Fsp050NqXik=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20220609170525-579cf78fd858 h1:Dpdu/EMxGMFgq0CeYMh4fazTD2vtlZRYE7wyynxJb9U=

--- a/internal/infra/config.go
+++ b/internal/infra/config.go
@@ -1,11 +1,13 @@
 package infra
 
+import "github.com/dependabot/cli/internal/model"
+
 // ConfigFilePath is the path to proxy config file.
 const ConfigFilePath = "/config.json"
 
 // Config is the structure of the proxy's config file
 type Config struct {
-	Credentials []map[string]string  `json:"all_credentials"`
+	Credentials []model.Credential   `json:"all_credentials"`
 	CA          CertificateAuthority `json:"ca"`
 }
 

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -120,8 +120,14 @@ func expandEnvironmentVariables(api *server.API, params RunParams) {
 	api.Actual.Input.Credentials = params.Creds
 
 	// Make a copy of the credentials, so we don't inject them into the output file.
-	params.Creds = make([]model.Credential, len(params.Creds))
-	copy(params.Creds, api.Actual.Input.Credentials)
+	params.Creds = []model.Credential{}
+	for _, cred := range api.Actual.Input.Credentials {
+		newCred := model.Credential{}
+		for k, v := range cred {
+			newCred[k] = v
+		}
+		params.Creds = append(params.Creds, newCred)
+	}
 
 	// Add the actual credentials from the environment.
 	for _, cred := range params.Creds {

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -121,7 +121,7 @@ func expandEnvironmentVariables(api *server.API, params RunParams) {
 
 	// Make a copy of the credentials, so we don't inject them into the output file.
 	params.Creds = make([]model.Credential, len(params.Creds))
-	copy(params.Creds, params.Creds)
+	copy(params.Creds, api.Actual.Input.Credentials)
 
 	// Add the actual credentials from the environment.
 	for _, cred := range params.Creds {

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -75,7 +75,7 @@ func Run(params RunParams) error {
 		defer outFile.Close()
 	}
 
-	expandEnvironmentVariables(api, params)
+	expandEnvironmentVariables(api, &params)
 
 	if err := runContainers(ctx, params, api); err != nil {
 		return err
@@ -116,7 +116,7 @@ func Run(params RunParams) error {
 	return nil
 }
 
-func expandEnvironmentVariables(api *server.API, params RunParams) {
+func expandEnvironmentVariables(api *server.API, params *RunParams) {
 	api.Actual.Input.Credentials = params.Creds
 
 	// Make a copy of the credentials, so we don't inject them into the output file.

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -25,7 +25,7 @@ type RunParams struct {
 	// expectations asserted at the end of a test
 	Expected []model.Output
 	// credentials passed to the proxy
-	Creds []map[string]string
+	Creds []model.Credential
 	// local directory used for caching
 	CacheDir string
 	// write output to a file
@@ -62,16 +62,6 @@ func Run(params RunParams) error {
 
 	api := server.NewAPI(params.Expected)
 	defer api.Stop()
-
-	token := os.Getenv("LOCAL_GITHUB_ACCESS_TOKEN")
-	if token != "" {
-		params.Creds = append(params.Creds, map[string]string{
-			"type":     "git_source",
-			"host":     "github.com",
-			"username": "x-access-token",
-			"password": token,
-		})
-	}
 
 	var outFile *os.File
 	if params.Output != "" {

--- a/internal/infra/run_test.go
+++ b/internal/infra/run_test.go
@@ -4,11 +4,12 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
-	"gopkg.in/yaml.v3"
 	"io"
 	"os"
 	"reflect"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/dependabot/cli/internal/model"
 	"github.com/docker/docker/api/types"

--- a/internal/infra/run_test.go
+++ b/internal/infra/run_test.go
@@ -110,6 +110,14 @@ func TestRun(t *testing.T) {
 		_, _ = cli.ImageRemove(ctx, UpdaterImageName, types.ImageRemoveOptions{})
 	}()
 
+	cred := model.Credential{
+		"type":     "git_source",
+		"host":     "github.com",
+		"username": "x-access-token",
+		"password": "$LOCAL_GITHUB_ACCESS_TOKEN",
+	}
+
+	os.Setenv("LOCAL_GITHUB_ACCESS_TOKEN", "test-token")
 	err = Run(RunParams{
 		PullImages: true,
 		Job: &model.Job{
@@ -118,12 +126,7 @@ func TestRun(t *testing.T) {
 				Repo: "org/name",
 			},
 		},
-		Creds: []model.Credential{{
-			"type":     "git_source",
-			"host":     "github.com",
-			"username": "x-access-token",
-			"password": "$LOCAL_GITHUB_ACCESS_TOKEN",
-		}},
+		Creds:  []model.Credential{cred},
 		Output: "out.yaml",
 	})
 	if err != nil {
@@ -141,10 +144,8 @@ func TestRun(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(output.Input.Credentials) == 0 {
-		t.Error("expected credentials to be populated")
-	} else if output.Input.Credentials[0]["password"] != "$LOCAL_GITHUB_ACCESS_TOKEN" {
-		t.Error("got unexpected credentials", output.Input.Credentials)
+	if !reflect.DeepEqual(output.Input.Credentials, []model.Credential{cred}) {
+		t.Error("unexpected credentials", output.Input.Credentials)
 	}
 }
 

--- a/internal/infra/run_test.go
+++ b/internal/infra/run_test.go
@@ -147,6 +147,9 @@ func TestRun(t *testing.T) {
 	if !reflect.DeepEqual(output.Input.Credentials, []model.Credential{cred}) {
 		t.Error("unexpected credentials", output.Input.Credentials)
 	}
+	if output.Input.Credentials[0]["password"] != "$LOCAL_GITHUB_ACCESS_TOKEN" {
+		t.Error("expected password to be masked")
+	}
 }
 
 const dockerFile = `

--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -2,24 +2,24 @@ package model
 
 // Job is the data that is passed to the updater.
 type Job struct {
-	PackageManager             string           `json:"package-manager" yaml:"package-manager"`
-	AllowedUpdates             []Allowed        `json:"allowed-updates" yaml:"allowed-updates,omitempty"`
-	Dependencies               []string         `json:"dependencies" yaml:"dependencies,omitempty"`
-	ExistingPullRequests       [][]ExistingPR   `json:"existing-pull-requests" yaml:"existing-pull-requests,omitempty"`
-	Experiments                Experiment       `json:"experiments" yaml:"experiments,omitempty"`
-	IgnoreConditions           []Condition      `json:"ignore-conditions" yaml:"ignore-conditions,omitempty"`
-	LockfileOnly               bool             `json:"lockfile-only" yaml:"lockfile-only,omitempty"`
-	RequirementsUpdateStrategy *string          `json:"requirements-update-strategy" yaml:"requirements-update-strategy,omitempty"`
-	SecurityAdvisories         []Advisory       `json:"security-advisories" yaml:"security-advisories,omitempty"`
-	SecurityUpdatesOnly        bool             `json:"security-updates-only" yaml:"security-updates-only,omitempty"`
-	Source                     Source           `json:"source" yaml:"source"`
-	UpdateSubdependencies      bool             `json:"update-subdependencies" yaml:"update-subdependencies,omitempty"`
-	UpdatingAPullRequest       bool             `json:"updating-a-pull-request" yaml:"updating-a-pull-request,omitempty"`
-	VendorDependencies         bool             `json:"vendor-dependencies" yaml:"vendor-dependencies,omitempty"`
-	RejectExternalCode         bool             `json:"reject-external-code" yaml:"reject-external-code,omitempty"`
-	CommitMessageOptions       *CommitOptions   `json:"commit-message-options" yaml:"commit-message-options,omitempty"`
-	CredentialsMetadata        []map[string]any `json:"credentials-metadata" yaml:"credentials-metadata,omitempty"`
-	MaxUpdaterRunTime          int              `json:"max-updater-run-time" yaml:"max-updater-run-time,omitempty"`
+	PackageManager             string         `json:"package-manager" yaml:"package-manager"`
+	AllowedUpdates             []Allowed      `json:"allowed-updates" yaml:"allowed-updates,omitempty"`
+	Dependencies               []string       `json:"dependencies" yaml:"dependencies,omitempty"`
+	ExistingPullRequests       [][]ExistingPR `json:"existing-pull-requests" yaml:"existing-pull-requests,omitempty"`
+	Experiments                Experiment     `json:"experiments" yaml:"experiments,omitempty"`
+	IgnoreConditions           []Condition    `json:"ignore-conditions" yaml:"ignore-conditions,omitempty"`
+	LockfileOnly               bool           `json:"lockfile-only" yaml:"lockfile-only,omitempty"`
+	RequirementsUpdateStrategy *string        `json:"requirements-update-strategy" yaml:"requirements-update-strategy,omitempty"`
+	SecurityAdvisories         []Advisory     `json:"security-advisories" yaml:"security-advisories,omitempty"`
+	SecurityUpdatesOnly        bool           `json:"security-updates-only" yaml:"security-updates-only,omitempty"`
+	Source                     Source         `json:"source" yaml:"source"`
+	UpdateSubdependencies      bool           `json:"update-subdependencies" yaml:"update-subdependencies,omitempty"`
+	UpdatingAPullRequest       bool           `json:"updating-a-pull-request" yaml:"updating-a-pull-request,omitempty"`
+	VendorDependencies         bool           `json:"vendor-dependencies" yaml:"vendor-dependencies,omitempty"`
+	RejectExternalCode         bool           `json:"reject-external-code" yaml:"reject-external-code,omitempty"`
+	CommitMessageOptions       *CommitOptions `json:"commit-message-options" yaml:"commit-message-options,omitempty"`
+	CredentialsMetadata        []Credential   `json:"credentials-metadata" yaml:"credentials-metadata,omitempty"`
+	MaxUpdaterRunTime          int            `json:"max-updater-run-time" yaml:"max-updater-run-time,omitempty"`
 }
 
 // Source is a reference to some source code
@@ -86,3 +86,5 @@ type CommitOptions struct {
 	PrefixDevelopment string  `json:"prefix-development,omitempty" yaml:"prefix-development,omitempty"`
 	IncludeScope      *string `json:"include-scope,omitempty" yaml:"include-scope,omitempty"`
 }
+
+type Credential map[string]any

--- a/internal/model/scenario.go
+++ b/internal/model/scenario.go
@@ -13,7 +13,7 @@ type Input struct {
 	// Job is the data given to the updater
 	Job Job `yaml:"job"`
 	// Credentials is the registry info and tokens to pass to the Proxy
-	Credentials []map[string]string `yaml:"credentials,omitempty"`
+	Credentials []Credential `yaml:"credentials,omitempty"`
 }
 
 // Output is the expected output given the inputs


### PR DESCRIPTION
When testing with credentials it's a bit redundant to have to specify the metadata in the job definition:

```yml
job:
  package-manager: docker
  allowed-updates:
    - update-type: all
  source:
    provider: github
    repo: dependabot/test
    directory: /docker
  credentials-metadata:
    - type: docker_registry
      registry: example.com
      replaces-base: true
    - type: docker_registry
      registry: example.com
credentials:
  - type: docker_registry
    registry: example.com
    username: user1
    password: $PW1
  - type: docker_registry
    registry: example.com
    username: user2
    password: $PW2
```

With this change, the following is equivalent to the above:

```yml
job:
  package-manager: docker
  allowed-updates:
    - update-type: all
  source:
    provider: github
    repo: dependabot/test
    directory: /docker
credentials:
  - type: docker_registry
    registry: example.com
    username: user1
    password: $PW1
    replaces-base: true
  - type: docker_registry
    registry: example.com
    username: user2
    password: $PW2
```

The CLI will automatically add the credentials-metadata section. This is more inline with how the dependabot.yml works.

I've also made the Credentials definitions all match up with a proper type rather than specifying a map everywhere.