### PR TITLE
improve result diffing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/docker/docker v20.10.21+incompatible
 	github.com/moby/moby v20.10.21+incompatible
 	github.com/moby/sys/signal v0.7.0
-	github.com/sergi/go-diff v1.2.0
 	github.com/spf13/cobra v1.6.1
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -22,6 +21,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/kr/pretty v0.1.0 // indirect
 	github.com/moby/term v0.0.0-20220808134915-39b0c02b01ae // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
@@ -33,5 +33,6 @@ require (
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
 	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/time v0.0.0-20220609170525-579cf78fd858 // indirect
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gotest.tools/v3 v3.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,6 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
-github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
@@ -65,7 +63,6 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -112,8 +109,6 @@ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8T
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -51,3 +51,8 @@ type RecordPackageManagerVersion struct {
 	Ecosystem       string         `json:"ecosystem" yaml:"ecosystem"`
 	PackageManagers map[string]any `json:"package-managers" yaml:"package-managers"`
 }
+
+type RecordUpdateJobError struct {
+	ErrorType    string `json:"error-type" yaml:"error-type"`
+	ErrorDetails string `json:"error-details" yaml:"error-details"`
+}

--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -53,6 +53,6 @@ type RecordPackageManagerVersion struct {
 }
 
 type RecordUpdateJobError struct {
-	ErrorType    string `json:"error-type" yaml:"error-type"`
-	ErrorDetails string `json:"error-details" yaml:"error-details"`
+	ErrorType    string         `json:"error-type" yaml:"error-type"`
+	ErrorDetails map[string]any `json:"error-details" yaml:"error-details"`
 }

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -192,7 +192,7 @@ func decodeWrapper(kind string, data []byte) (actual *model.UpdateWrapper, err e
 	case "record_package_manager_version":
 		actual.Data, err = decode[model.RecordPackageManagerVersion](data)
 	case "record_update_job_error":
-		actual.Data, err = decode[map[string]any](data)
+		actual.Data, err = decode[model.RecordUpdateJobError](data)
 	default:
 		return nil, fmt.Errorf("unexpected output type: %s", kind)
 	}
@@ -226,6 +226,8 @@ func compare(expect, actual *model.UpdateWrapper) error {
 		return compareRecordPackageManagerVersion(v, actual.Data.(model.RecordPackageManagerVersion))
 	case model.MarkAsProcessed:
 		return compareMarkAsProcessed(v, actual.Data.(model.MarkAsProcessed))
+	case model.RecordUpdateJobError:
+		return compareRecordUpdateJobError(v, actual.Data.(model.RecordUpdateJobError))
 	default:
 		return fmt.Errorf("unexpected type: %s", reflect.TypeOf(v))
 	}
@@ -271,4 +273,11 @@ func compareMarkAsProcessed(expect, actual model.MarkAsProcessed) error {
 		return nil
 	}
 	return fmt.Errorf("mark as processed was unexpected")
+}
+
+func compareRecordUpdateJobError(expect, actual model.RecordUpdateJobError) error {
+	if reflect.DeepEqual(expect, actual) {
+		return nil
+	}
+	return fmt.Errorf("record update job error was unexpected")
 }

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/dependabot/cli/internal/model"
-	"gopkg.in/yaml.v3"
 	"io"
 	"log"
 	"net"
@@ -17,6 +15,9 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/dependabot/cli/internal/model"
+	"gopkg.in/yaml.v3"
 )
 
 // API intercepts calls to the Dependabot API

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1,0 +1,14 @@
+package server
+
+import (
+	"testing"
+)
+
+func Test_decodeWrapper(t *testing.T) {
+	t.Run("reject extra data", func(t *testing.T) {
+		_, err := decodeWrapper("update_dependency_list", []byte(`data: {"unknown": "value"}`))
+		if err == nil {
+			t.Error("expected decode would error on extra data")
+		}
+	})
+}


### PR DESCRIPTION
@pavera is developing a smoke test for the Yarn Berry ecosystem which caches binaries by default. 

This has rendered the diff view in the CLI useless, and actually a hinderance as I ran his test and the amount of output to stdout caused the updater to timeout!

Also the comparison of the expected and actual is slightly busted since it compares data we've unmarshalled into our model with the raw JSON coming in from a request. This has the result of some Go-isms (like default value vs null) being applied to one side and not the other.

Originally I did it this way because I was afraid our model was off, which we found in time that it was. Now that things are settling I have more confidence, but I've also added a line to the YAML decoder which will error if an unexpected value is encountered.

So this PR:
1. Removes the diff output
2. Compares the payload after being marshaled into our model

In the future I want to bring the diff output back but have it smart about what type it's diffing, which is why I broke out the different compare functions. I'll fill those in in the future!