### PR TITLE
Readme: fix option in gh-based install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ you can install the latest release of `dependabot` using the following command
 ([gist source](https://gist.github.com/mattt/e09e1ecd76d5573e0517a7622009f06f)):
 
 ```console
-$ gh gist view --raw e09e1ecd76d5573e0517a7622009f06f | bash
+$ gh gist view --filename=install.sh e09e1ecd76d5573e0517a7622009f06f | bash
 ```
 
 ## Requirements


### PR DESCRIPTION
`gh gist view --raw ...` outputs this:

```txt
Install the dependabot CLI

#!/usr/bin/env bash
...
```

After piping this file to bash, the first line shows an error.

With `--filename=install.sh` instead of `--raw`:

```bash
#!/usr/bin/env bash
...
```

And that error disappears.

I'm on gh version 2.20.2 (2022-11-15), latest.