### PR TITLE
run update-ca-certificates as dependabot

### DIFF
--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -205,10 +205,6 @@ func runContainers(ctx context.Context, params RunParams, api *server.API) error
 	}
 	defer updater.Close()
 
-	if err := updater.InstallCertificates(ctx); err != nil {
-		return err
-	}
-
 	if params.Debug {
 		if err := updater.RunShell(ctx, prox.url, api.Port()); err != nil {
 			return err


### PR DESCRIPTION
I'm granting permission for the dependabot user to run `update-ca-certificates` so there's no need for a separate step as root. 

The smoke tests will fail until I get the PR merged in core. 