### PR TITLE
fix certs not installed in debug mode

### DIFF
--- a/internal/infra/updater.go
+++ b/internal/infra/updater.go
@@ -170,7 +170,7 @@ func (u *Updater) RunShell(ctx context.Context, proxyURL string, apiPort int) er
 		Tty:          true,
 		User:         dependabot,
 		Env:          append(userEnv(proxyURL, apiPort), "DEBUG=1"),
-		Cmd:          []string{"/bin/bash"},
+		Cmd:          []string{"/bin/bash", "-c", "update-ca-certificates && /bin/bash"},
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create exec: %w", err)


### PR DESCRIPTION
In #46 I removed the call to "update-ca-certificates" as root and moved it into the "RunUpdate" function but forgot about the "RunShell" function. So this morning when I tried to run in debug I got a cert error. This fixes it!