### PR TITLE
add support for pulling ecosystem images

### DIFF
--- a/cmd/dependabot/internal/cmd/root.go
+++ b/cmd/dependabot/internal/cmd/root.go
@@ -20,6 +20,8 @@ var (
 	pullImages    bool
 	volumes       []string
 	timeout       time.Duration
+	updaterImage  string
+	proxyImage    string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -42,6 +44,6 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&infra.UpdaterImageName, "updater-image", infra.UpdaterImageName, "container image to use for the updater")
-	rootCmd.PersistentFlags().StringVar(&infra.ProxyImageName, "proxy-image", infra.ProxyImageName, "container image to use for the proxy")
+	rootCmd.PersistentFlags().StringVar(&updaterImage, "updater-image", "", "container image to use for the updater")
+	rootCmd.PersistentFlags().StringVar(&proxyImage, "proxy-image", infra.ProxyImageName, "container image to use for the proxy")
 }

--- a/cmd/dependabot/internal/cmd/test.go
+++ b/cmd/dependabot/internal/cmd/test.go
@@ -45,8 +45,10 @@ var testCmd = &cobra.Command{
 			Job:           &scenario.Input.Job,
 			Output:        output,
 			ProxyCertPath: proxyCertPath,
+			ProxyImage:    proxyImage,
 			PullImages:    pullImages,
 			Timeout:       timeout,
+			UpdaterImage:  updaterImage,
 			Volumes:       volumes,
 		}); err != nil {
 			log.Fatal(err)

--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -119,8 +119,10 @@ var updateCmd = &cobra.Command{
 			Job:           &input.Job,
 			Output:        output,
 			ProxyCertPath: proxyCertPath,
+			ProxyImage:    proxyImage,
 			PullImages:    pullImages,
 			Timeout:       timeout,
+			UpdaterImage:  updaterImage,
 			Volumes:       volumes,
 		}); err != nil {
 			log.Fatalf("failed to run updater: %v", err)

--- a/internal/infra/proxy.go
+++ b/internal/infra/proxy.go
@@ -27,8 +27,8 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
-// ProxyImageName is the docker image used by the proxy
-var ProxyImageName = "ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy:latest"
+// ProxyImageName is the default Docker image used by the proxy
+const ProxyImageName = "ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy:latest"
 
 type Proxy struct {
 	cli           *client.Client
@@ -86,7 +86,7 @@ func NewProxy(ctx context.Context, cli *client.Client, params *RunParams, nets .
 		})
 	}
 	config := &container.Config{
-		Image: ProxyImageName,
+		Image: params.ProxyImage,
 		Env: []string{
 			"JOB_ID=" + jobID,
 			"PROXY_CACHE=true",

--- a/internal/infra/proxy_test.go
+++ b/internal/infra/proxy_test.go
@@ -82,12 +82,8 @@ func TestNewProxy_customCert(t *testing.T) {
 	_ = addFileToArchive(tw, "/Dockerfile", 0644, proxyTestDockerfile)
 	_ = tw.Close()
 
-	tmp := ProxyImageName
-	defer func() {
-		ProxyImageName = tmp
-	}()
-	ProxyImageName = "curl-test"
-	resp, err := cli.ImageBuild(ctx, &buildContext, types.ImageBuildOptions{Tags: []string{ProxyImageName}})
+	proxyImageName := "curl-test"
+	resp, err := cli.ImageBuild(ctx, &buildContext, types.ImageBuildOptions{Tags: []string{proxyImageName}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,11 +91,12 @@ func TestNewProxy_customCert(t *testing.T) {
 	_ = resp.Body.Close()
 
 	defer func() {
-		_, _ = cli.ImageRemove(ctx, ProxyImageName, types.ImageRemoveOptions{})
+		_, _ = cli.ImageRemove(ctx, proxyImageName, types.ImageRemoveOptions{})
 	}()
 
 	proxy, err := NewProxy(ctx, cli, &RunParams{
 		ProxyCertPath: cert.Name(),
+		ProxyImage:    proxyImageName,
 	})
 	if err != nil {
 		panic(err)

--- a/internal/infra/run_test.go
+++ b/internal/infra/run_test.go
@@ -130,7 +130,7 @@ func TestRun(t *testing.T) {
 	_ = addFileToArchive(tw, "/test_main.go", 0644, testMain)
 	_ = tw.Close()
 
-	UpdaterImageName = "test-updater"
+	UpdaterImageName := "test-updater"
 	resp, err := cli.ImageBuild(ctx, &buildContext, types.ImageBuildOptions{Tags: []string{UpdaterImageName}})
 	if err != nil {
 		t.Fatal(err)
@@ -159,8 +159,9 @@ func TestRun(t *testing.T) {
 				Repo: "org/name",
 			},
 		},
-		Creds:  []model.Credential{cred},
-		Output: "out.yaml",
+		Creds:        []model.Credential{cred},
+		UpdaterImage: UpdaterImageName,
+		Output:       "out.yaml",
 	})
 	if err != nil {
 		t.Error(err)

--- a/internal/infra/updater.go
+++ b/internal/infra/updater.go
@@ -25,9 +25,6 @@ import (
 const jobID = "cli"
 const dependabot = "dependabot"
 
-// UpdaterImageName is the docker image used by the updater
-var UpdaterImageName = "ghcr.io/dependabot/dependabot-updater:latest"
-
 const (
 	guestInputDir = "/home/dependabot/dependabot-updater/job.json"
 	guestOutput   = "/home/dependabot/dependabot-updater/output.json"
@@ -48,7 +45,7 @@ const (
 func NewUpdater(ctx context.Context, cli *client.Client, net *Networks, params *RunParams, prox *Proxy) (*Updater, error) {
 	containerCfg := &container.Config{
 		User:  dependabot,
-		Image: UpdaterImageName,
+		Image: params.UpdaterImage,
 		Cmd:   []string{"/bin/sh"},
 		Tty:   true, // prevent container from stopping
 	}


### PR DESCRIPTION
With this change, Dependabot CLI will automatically pull the correct Updater image to use during the update.

This shouldn't affect any of our smoke tests as we always build the image we're testing and pass it in with `--updater-image`. 