### PR TITLE
prevent update from using token with write access

### DIFF
--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -163,7 +163,7 @@ func checkCredAccess(ctx context.Context, creds []model.Credential) error {
 			return fmt.Errorf("failed request to GitHub API: %s", resp.Status)
 		}
 		scopes := resp.Header.Get("X-OAuth-Scopes")
-		if strings.Contains(scopes, "write") {
+		if strings.Contains(scopes, "write") || strings.Contains(scopes, "delete") {
 			return ErrWriteAccess
 		}
 	}

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -128,7 +128,7 @@ func Run(params RunParams) error {
 	return nil
 }
 
-var credAuthEndpoint = "https://api.github.com"
+var authEndpoint = "https://api.github.com"
 
 // checkCredAccess returns an error if any of the tokens in the job definition have write access.
 // Some package managers can execute arbitrary code during an update. The credentials are not accessible to the updater,
@@ -138,15 +138,15 @@ func checkCredAccess(ctx context.Context, creds []model.Credential) error {
 	for _, cred := range creds {
 		var credential string
 		if password, ok := cred["password"]; ok && password != "" {
-			credential = password.(string)
+			credential, _ = password.(string)
 		}
 		if token, ok := cred["token"]; ok && token != "" {
-			credential = token.(string)
+			credential, _ = token.(string)
 		}
 		if !strings.HasPrefix(credential, "ghp_") {
 			continue
 		}
-		r, err := http.NewRequestWithContext(ctx, "GET", credAuthEndpoint, nil)
+		r, err := http.NewRequestWithContext(ctx, "GET", authEndpoint, http.NoBody)
 		if err != nil {
 			return fmt.Errorf("failed creating request: %w", err)
 		}

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -128,7 +128,10 @@ func Run(params RunParams) error {
 	return nil
 }
 
-var authEndpoint = "https://api.github.com"
+var (
+	authEndpoint   = "https://api.github.com"
+	ErrWriteAccess = fmt.Errorf("for security, credentials used in update are not allowed to have write access to GitHub API")
+)
 
 // checkCredAccess returns an error if any of the tokens in the job definition have write access.
 // Some package managers can execute arbitrary code during an update. The credentials are not accessible to the updater,
@@ -161,7 +164,7 @@ func checkCredAccess(ctx context.Context, creds []model.Credential) error {
 		}
 		scopes := resp.Header.Get("X-OAuth-Scopes")
 		if strings.Contains(scopes, "write") {
-			return fmt.Errorf("for security, credentials used in update are not allowed to have write access to GitHub API")
+			return ErrWriteAccess
 		}
 	}
 	return nil

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -161,7 +161,7 @@ func checkCredAccess(ctx context.Context, creds []model.Credential) error {
 		}
 		scopes := resp.Header.Get("X-OAuth-Scopes")
 		if strings.Contains(scopes, "write") {
-			return fmt.Errorf("credentials used in update may not have write access to GitHub API")
+			return fmt.Errorf("for security, credentials used in update are not allowed to have write access to GitHub API")
 		}
 	}
 	return nil

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -6,14 +6,15 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
-	"github.com/dependabot/cli/internal/server"
-
 	"github.com/dependabot/cli/internal/model"
+	"github.com/dependabot/cli/internal/server"
 	"github.com/docker/docker/api/types"
 	"github.com/moby/moby/client"
 	"gopkg.in/yaml.v3"
@@ -80,6 +81,10 @@ func Run(params RunParams) error {
 	}
 
 	expandEnvironmentVariables(api, &params)
+	if err := checkCredAccess(ctx, params.Creds); err != nil {
+		return err
+	}
+
 	if err := setImageNames(&params); err != nil {
 		return err
 	}
@@ -120,6 +125,45 @@ func Run(params RunParams) error {
 		return fmt.Errorf("update failed expectations")
 	}
 
+	return nil
+}
+
+var credAuthEndpoint = "https://api.github.com"
+
+// checkCredAccess returns an error if any of the tokens in the job definition have write access.
+// Some package managers can execute arbitrary code during an update. The credentials are not accessible to the updater,
+// but the proxy injects them in requests, and the updater could execute arbitrary requests. So to be safe, disallow
+// write access on these tokens.
+func checkCredAccess(ctx context.Context, creds []model.Credential) error {
+	for _, cred := range creds {
+		var credential string
+		if password, ok := cred["password"]; ok && password != "" {
+			credential = password.(string)
+		}
+		if token, ok := cred["token"]; ok && token != "" {
+			credential = token.(string)
+		}
+		if !strings.HasPrefix(credential, "ghp_") {
+			continue
+		}
+		r, err := http.NewRequestWithContext(ctx, "GET", credAuthEndpoint, nil)
+		if err != nil {
+			return fmt.Errorf("failed creating request: %w", err)
+		}
+		r.Header.Set("Authorization", fmt.Sprintf("token %s", credential))
+		r.Header.Set("User-Agent", "dependabot-cli")
+		resp, err := http.DefaultClient.Do(r)
+		if err != nil {
+			return fmt.Errorf("failed making request: %w", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("failed request to GitHub API: %s", resp.Status)
+		}
+		scopes := resp.Header.Get("X-OAuth-Scopes")
+		if strings.Contains(scopes, "write") {
+			return fmt.Errorf("credentials used in update may not have write access to GitHub API")
+		}
+	}
 	return nil
 }
 

--- a/internal/infra/run_test.go
+++ b/internal/infra/run_test.go
@@ -23,9 +23,14 @@ import (
 func Test_checkCredAccess(t *testing.T) {
 	t.Run("returns error if the credential has write access", func(t *testing.T) {
 		credAuthEndpoint = "http://127.0.0.1:3000"
+		addr := "127.0.0.1:3000"
+		if os.Getenv("CI") != "" {
+			t.Log("detected running in actions")
+			addr = "0.0.0.0:3000"
+		}
 		testServer := &http.Server{
 			ReadHeaderTimeout: time.Second,
-			Addr:              "127.0.0.1:3000",
+			Addr:              addr,
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("X-OAuth-Scopes", "repo, write:packages")
 				_, _ = w.Write([]byte("SUCCESS"))

--- a/internal/infra/run_test.go
+++ b/internal/infra/run_test.go
@@ -5,9 +5,11 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"net/http"
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/dependabot/cli/internal/server"
 
@@ -17,6 +19,36 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/moby/moby/client"
 )
+
+func Test_checkCredAccess(t *testing.T) {
+	t.Run("returns error if the credential has write access", func(t *testing.T) {
+		credAuthEndpoint = "http://127.0.0.1:3000"
+		testServer := &http.Server{
+			ReadHeaderTimeout: time.Second,
+			Addr:              "127.0.0.1:3000",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("X-OAuth-Scopes", "repo, write:packages")
+				_, _ = w.Write([]byte("SUCCESS"))
+			}),
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		defer func() {
+			_ = testServer.Shutdown(ctx)
+		}()
+		go func() {
+			_ = testServer.ListenAndServe()
+		}()
+
+		credentials := []model.Credential{{
+			"token": "ghp_fake",
+		}}
+		err := checkCredAccess(ctx, credentials)
+		if err.Error() != "credentials used in update may not have write access to GitHub API" {
+			t.Error("unexpected error", err)
+		}
+	})
+}
 
 func Test_expandEnvironmentVariables(t *testing.T) {
 	t.Run("injects environment variables", func(t *testing.T) {

--- a/internal/infra/run_test.go
+++ b/internal/infra/run_test.go
@@ -50,7 +50,7 @@ func Test_checkCredAccess(t *testing.T) {
 			"token": "ghp_fake",
 		}}
 		err := checkCredAccess(ctx, credentials)
-		if err.Error() != "credentials used in update may not have write access to GitHub API" {
+		if err != ErrWriteAccess {
 			t.Error("unexpected error", err)
 		}
 	})

--- a/internal/infra/run_test.go
+++ b/internal/infra/run_test.go
@@ -44,6 +44,7 @@ func Test_checkCredAccess(t *testing.T) {
 		go func() {
 			_ = testServer.ListenAndServe()
 		}()
+		time.Sleep(1 * time.Millisecond) // allow time for the server to start
 
 		credentials := []model.Credential{{
 			"token": "ghp_fake",

--- a/internal/infra/run_test.go
+++ b/internal/infra/run_test.go
@@ -22,7 +22,7 @@ import (
 
 func Test_checkCredAccess(t *testing.T) {
 	t.Run("returns error if the credential has write access", func(t *testing.T) {
-		credAuthEndpoint = "http://127.0.0.1:3000"
+		authEndpoint = "http://127.0.0.1:3000"
 		addr := "127.0.0.1:3000"
 		if os.Getenv("CI") != "" {
 			t.Log("detected running in actions")


### PR DESCRIPTION
Adds a check to see if the token being used for the update has any write access. Using a token with write access could be abused since some package managers allow arbitrary code execution. This means they could make any HTTP request and the proxy would add credentials to the request.

So to prevent that we check the credentials and disallow the update if it has write access.

To do that check, we can call api.github.com with the credential and check the scope returned in the headers.