### PR TITLE
output errors during updates

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -120,6 +120,11 @@ func (a *API) ServeHTTP(_ http.ResponseWriter, r *http.Request) {
 	}
 
 	if !a.hasExpectations {
+		// When running an update, there's no way to see the error in the record_update_job_error,
+		// but it's handy to see it in the logs for debugging.
+		if kind == "record_update_job_error" {
+			log.Println("update-job error:", actual.Data)
+		}
 		return
 	}
 


### PR DESCRIPTION
When debugging issues with the CLI, if there's an error it can be frustrating as you will see a log message like `ERROR <job_cli> Error during file fetching; aborting` but it doesn't actually output what the error is. To capture it, you have to use `-o` to specify an output file and then examine the error that gets sent to the API.

With this change, it outputs the error like this:

```
update-job error: {dependency_file_not_found map[file-path:/missing/go.mod]}
```
