### PR TITLE
Add the GroupedUpdate field to CreatePullRequest

### DIFF
--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -16,6 +16,7 @@ type CreatePullRequest struct {
 	PRTitle                string           `json:"pr-title" yaml:"pr-title,omitempty"`
 	PRBody                 string           `json:"pr-body" yaml:"pr-body,omitempty"`
 	CommitMessage          string           `json:"commit-message" yaml:"commit-message,omitempty"`
+	GroupedUpdate          bool             `json:"grouped-update" yaml:"grouped-update"`
 }
 
 type UpdatePullRequest struct {


### PR DESCRIPTION
This is a question in PR form, apologies!

As part of the grouped update spike, we are going to add a [new field](https://github.com/dependabot/dependabot-core/pull/6663/files#diff-1f8c3901647148d6f9fbda3a5c943490beb28c1291f21a3b6713471e0c39902bR205-R207) that is sent when the PR is created indicating if it was generated from a "Group Rule" or not.

In future this flag is likely to come along with a small value object that has the id/name/etc of the group rule.

On my spike, I get errors from the CLI that this column is not validate as part of the CreatePullRequest struct, so the obvious answer is to add it!

The less obvious part is the sequence I should following in doing this as right now the field is only sent if:
- You are using my spike
- You have an experiment enabled

My plan is to open a PR which adds the column, sent as 'false' by default to core soon ™️. As part of that, I'll need to update the end 2 end tests for the CLI to include it, so I'll potentially need to change the CLI first, but it seems like that could be a 🐔 and 🥚 problem where tests will fail _somewhere_ until both merge.

So my question is this: would the easiest approach be to add `GroupedUpdate` with `omitempty`, on the assumption that existing end-to-end tests will still pass until I update core, then circle back and do a subsequent update to the CLI which removes the `omitempty` ?