### PR TITLE
improve logging

### DIFF
--- a/cmd/dependabot/internal/cmd/root.go
+++ b/cmd/dependabot/internal/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"log"
 	"os"
 	"time"
 
@@ -44,6 +45,9 @@ func Execute() {
 }
 
 func init() {
+	log.SetFlags(log.Ldate | log.Ltime | log.LUTC)
+	log.SetPrefix("cli | ")
+
 	rootCmd.PersistentFlags().StringVar(&updaterImage, "updater-image", "", "container image to use for the updater")
 	rootCmd.PersistentFlags().StringVar(&proxyImage, "proxy-image", infra.ProxyImageName, "container image to use for the proxy")
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/docker/cli v23.0.1+incompatible
 	github.com/docker/docker v23.0.1+incompatible
+	github.com/goware/prefixer v0.0.0-20160118172347-395022866408
 	github.com/moby/moby v23.0.1+incompatible
 	github.com/moby/sys/signal v0.7.0
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/goware/prefixer v0.0.0-20160118172347-395022866408 h1:Y9iQJfEqnN3/Nce9cOegemcy/9Ai5k3huT6E80F3zaw=
+github.com/goware/prefixer v0.0.0-20160118172347-395022866408/go.mod h1:PE1ycukgRPJ7bJ9a1fdfQ9j8i/cEcRAoLZzbxYpNB/s=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/internal/infra/proxy.go
+++ b/internal/infra/proxy.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/goware/prefixer"
+	"io"
 	"math/rand"
 	"os"
 	"path"
@@ -154,7 +156,11 @@ func (p *Proxy) TailLogs(ctx context.Context, cli *client.Client) {
 		return
 	}
 
-	_, _ = stdcopy.StdCopy(os.Stdout, os.Stderr, out)
+	r, w := io.Pipe()
+	go func() {
+		_, _ = io.Copy(os.Stderr, prefixer.New(r, "proxy | "))
+	}()
+	_, _ = stdcopy.StdCopy(w, w, out)
 }
 
 func (p *Proxy) Close() error {


### PR DESCRIPTION
This changes the CLI timestamp to UTC to match the proxy.

Also adds prefixes to the different systems logging which makes it look nice and you can tell what is going on a bit better. Took this idea from the action.

Here's a sample:

```
➜  cli git:(main) ✗ go run cmd/dependabot/dependabot.go update --dry-run go_modules rsc/quote
cli | 2023/03/15 18:23:37 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
cli | 2023/03/15 18:23:37 Adding missing credentials-metadata into job definition
cli | 2023/03/15 18:23:37 using image ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy:latest at sha256:1ead1b78e35f6ca58fee24dbf25b6ef9bf552fb7b8c8d17e6326c4f976d09655
cli | 2023/03/15 18:23:37 using image ghcr.io/dependabot/dependabot-updater-gomod at sha256:fbec5f800ec20ab032996e261daa76f044f5d0a92da4586f018e0bdd0c780b12
proxy | time="2023-03-15T18:23:38Z" level=info msg="proxy starting" commit=355773269f680819804045fce32d9cc7c865833e
proxy | time="2023-03-15T18:23:38Z" level=warning msg="initializing metrics client" error="No address passed and autodetection from environment failed"
proxy | 2023/03/15 18:23:38 Listening (:1080)
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | done.
updater | I, [2023-03-15T18:23:39.724688 #911]  INFO -- sentry: ** [Raven] Raven 3.1.2 configured not to capture errors: DSN not set
updater | INFO Starting job processing
proxy | 2023/03/15 18:23:40 [002] GET https://github.com:443/rsc/quote/info/refs?service=git-upload-pack
proxy | 2023/03/15 18:23:40 [002] * authenticating git server request (host: github.com)
```