### PR TITLE
cleanup the "update" subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Usage:
   dependabot [command]
 
 Examples:
-  $ dependabot update go_modules rsc/quote --dry-run
+  $ dependabot update go_modules rsc/quote
   $ dependabot test -f scenario.yaml
 
 Available Commands:
@@ -56,12 +56,11 @@ Use "dependabot [command] --help" for more information about a command.
 
 ### `dependabot update`
 
-Run the `update` subcommand with the `--dry-run` flag to
-simulate a Dependabot update job for the provided ecosystem and repo
-(without actually creating any PRs).
+Run the `update` subcommand to run a Dependabot update job for the provided ecosystem and repo.
+This does not create PRs, but outputs data that could be used to create PRs.
 
 ```console
-$ dependabot update go_modules rsc/quote --dry-run
+$ dependabot update go_modules rsc/quote
 # ...
 +----------------------------------------------------+
 |        Changes to Dependabot Pull Requests         |
@@ -103,7 +102,7 @@ using the `--file` / `-f` option
 (this replaces the package manager and repository name arguments).
 
 ```console
-dependabot update -f job.yaml --dry-run
+dependabot update -f job.yaml
 ```
 
 ```yaml
@@ -265,7 +264,7 @@ To produce a scenario file that tests Dependabot behavior for a given repo,
 run the `update` subcommand and set the `--output` / `-o` option to a file path.
 
 ```console
-dependabot update go_modules rsc/quote --dry-run -o go-scenario.yml
+dependabot update go_modules rsc/quote -o go-scenario.yml
 ```
 
 Run the `test` subcommand for the generated scenario file,

--- a/cmd/dependabot/internal/cmd/root.go
+++ b/cmd/dependabot/internal/cmd/root.go
@@ -31,7 +31,7 @@ var rootCmd = &cobra.Command{
 	Short: "Dependabot end-to-end runner",
 	Long:  `Run Dependabot jobs from the command line.`,
 	Example: heredoc.Doc(`
-        $ dependabot update go_modules rsc/quote --dry-run
+        $ dependabot update go_modules rsc/quote
         $ dependabot test -f input.yml
 	`),
 	Version: Version(),

--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -23,13 +23,12 @@ var (
 	repo           string
 	directory      string
 
-	dryRun          bool
 	inputServerPort int
 )
 
 var updateCmd = &cobra.Command{
 	Use:   "update <package_manager> <repo> [flags]",
-	Short: "Perform update job",
+	Short: "Perform an update job",
 	Example: heredoc.Doc(`
 		    $ dependabot update go_modules rsc/quote
 	    `),

--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -31,7 +31,7 @@ var updateCmd = &cobra.Command{
 	Use:   "update <package_manager> <repo> [flags]",
 	Short: "Perform update job",
 	Example: heredoc.Doc(`
-		    $ dependabot update go_modules rsc/quote --dry-run
+		    $ dependabot update go_modules rsc/quote
 	    `),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var outFile *os.File
@@ -213,10 +213,9 @@ func processInput(input *model.Input) {
 }
 
 func doesStdinHaveData() bool {
-	file := os.Stdin
-	fi, err := file.Stat()
+	fi, err := os.Stdin.Stat()
 	if err != nil {
-		fmt.Println("file.Stat()", err)
+		log.Println("file.Stat()", err)
 	}
 	return fi.Size() > 0
 }
@@ -228,9 +227,6 @@ func init() {
 
 	updateCmd.Flags().StringVarP(&provider, "provider", "p", "github", "provider of the repository")
 	updateCmd.Flags().StringVarP(&directory, "directory", "d", "/", "directory to update")
-
-	updateCmd.Flags().BoolVar(&dryRun, "dry-run", true, "perform update as a dry run")
-	_ = updateCmd.MarkFlagRequired("dry-run")
 
 	updateCmd.Flags().StringVarP(&output, "output", "o", "", "write scenario to file")
 	updateCmd.Flags().StringVar(&cache, "cache", "", "cache import/export directory")

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -4,11 +4,11 @@ This guide will help you debug issues with your Dependabot update using the Depe
 
 ## Getting started
 
-First, test to make sure you have a working Dependabot CLI by performing a simple update, like `dependabot update --dry-run go_modules rsc/quote -o out.yml`. This should complete without error, and you can examine the out.yml file which should contain two calls to `create_pull_request`.
+First, test to make sure you have a working Dependabot CLI by performing a simple update, like `dependabot update go_modules rsc/quote -o out.yml`. This should complete without error, and you can examine the out.yml file which should contain two calls to `create_pull_request`.
 
 Next, clone https://github.com/dependabot/dependabot-core. This project contains all the source for the updater images, and a helpful script `script/dependabot` which will mount the ecosystems in the container that the CLI starts.
 
-Try opening a terminal and run `script/dependabot update --dry-run go_modules rsc/quote --debug` in the `dependabot-core` project directory. This will drop you in an interactive session with the update ready to proceed.
+Try opening a terminal and run `script/dependabot update go_modules rsc/quote --debug` in the `dependabot-core` project directory. This will drop you in an interactive session with the update ready to proceed.
 
 To perform the update, you need to run two commands:
 
@@ -60,7 +60,7 @@ At this prompt, you can run [debugger commands](https://github.com/ruby/debug) t
 
 If your Dependabot job is hanging and would like to figure out why, the CLI is the perfect tool for the job. 
 
-Start by running the update that recreates the hang with `dependabot update --dry-run <ecosystem> <org/repo>`. Once the hang is reproducible, run with the `--debug` flag and the run the `fetch_files` and `update_files` commands and wait until the job hangs.
+Start by running the update that recreates the hang with `dependabot update <ecosystem> <org/repo>`. Once the hang is reproducible, run with the `--debug` flag and the run the `fetch_files` and `update_files` commands and wait until the job hangs.
 
 Once it does hang, hit CTL-C, and you'll get a stack trace leading you to the problematic code.
 

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -122,10 +122,13 @@ func (a *API) ServeHTTP(_ http.ResponseWriter, r *http.Request) {
 	}
 
 	if !a.hasExpectations {
-		// When running an update, there's no way to see the error in the record_update_job_error,
-		// but it's handy to see it in the logs for debugging.
-		if kind == "record_update_job_error" {
-			log.Println("update-job error:", actual.Data)
+		// output the data received to stdout
+		if err = json.NewEncoder(os.Stdout).Encode(map[string]any{
+			"type": kind,
+			"data": actual.Data,
+		}); err != nil {
+			// Fail so the user knows stdout is not working
+			log.Panicln("Failed to write to stdout: ", err)
 		}
 		return
 	}


### PR DESCRIPTION
This does a few small things to improve the update command:

1. Remove the dry-run flag which was required but has no effect. Also updated the docs to remove the flag.
2. Removes the error logging for the update command, as this is now done in core: https://github.com/dependabot/dependabot-core/pull/6761.
3. Outputs the updater calls to stdout to make it easier to integrate with the CLI. 
