### PR TITLE
prevent using a file and arguments at the same time

### DIFF
--- a/cmd/dependabot/internal/cmd/test.go
+++ b/cmd/dependabot/internal/cmd/test.go
@@ -18,7 +18,7 @@ var (
 )
 
 var testCmd = &cobra.Command{
-	Use:   "test [-f file]",
+	Use:   "test -f <scenario.yml>",
 	Short: "Test scenarios",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if jobs < 1 {

--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -27,10 +27,11 @@ var (
 )
 
 var updateCmd = &cobra.Command{
-	Use:   "update <package_manager> <repo> [flags]",
+	Use:   "update [<package_manager> <repo> | -f <input.yml>] [flags]",
 	Short: "Perform an update job",
 	Example: heredoc.Doc(`
 		    $ dependabot update go_modules rsc/quote
+		    $ dependabot update -f input.yml
 	    `),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var outFile *os.File
@@ -46,6 +47,9 @@ var updateCmd = &cobra.Command{
 		input := &model.Input{}
 
 		if file != "" {
+			if len(cmd.Flags().Args()) > 0 {
+				return errors.New("cannot use file and arguments together")
+			}
 			var err error
 			input, err = readInputFile(file)
 			if err != nil {


### PR DESCRIPTION
It's currently possible to do `dependabot update bundler my/repo -f input.yml` which is not clear what should happen.

When you run as `dependabot update bundler my/repo` this is a convenience to get started with Dependabot CLI. Not every option maps to a flag though, so most of the time you end up with an input file `dependabot update -f input.yml`. Mixing the two is not intended to be a feature.

This PR prevents using the two together. I also cleaned up the usage output and added an example. 