### PR TITLE
only use stdout with "update" subcommand while not debugging

### DIFF
--- a/cmd/dependabot/internal/cmd/test.go
+++ b/cmd/dependabot/internal/cmd/test.go
@@ -51,7 +51,6 @@ var testCmd = &cobra.Command{
 			PullImages:    pullImages,
 			Timeout:       timeout,
 			UpdaterImage:  updaterImage,
-			UseStdout:     false,
 			Volumes:       volumes,
 		}); err != nil {
 			log.Fatal(err)

--- a/cmd/dependabot/internal/cmd/test.go
+++ b/cmd/dependabot/internal/cmd/test.go
@@ -49,6 +49,7 @@ var testCmd = &cobra.Command{
 			PullImages:    pullImages,
 			Timeout:       timeout,
 			UpdaterImage:  updaterImage,
+			UseStdout:     false,
 			Volumes:       volumes,
 		}); err != nil {
 			log.Fatal(err)

--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -126,6 +126,7 @@ var updateCmd = &cobra.Command{
 			PullImages:    pullImages,
 			Timeout:       timeout,
 			UpdaterImage:  updaterImage,
+			UseStdout:     !debugging,
 			Volumes:       volumes,
 		}); err != nil {
 			log.Fatalf("failed to run updater: %v", err)

--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -114,6 +114,11 @@ var updateCmd = &cobra.Command{
 
 		processInput(input)
 
+		var writer io.Writer
+		if !debugging {
+			writer = os.Stdout
+		}
+
 		if err := infra.Run(infra.RunParams{
 			CacheDir:      cache,
 			Creds:         input.Credentials,
@@ -129,7 +134,7 @@ var updateCmd = &cobra.Command{
 			PullImages:    pullImages,
 			Timeout:       timeout,
 			UpdaterImage:  updaterImage,
-			UseStdout:     !debugging,
+			Writer:        writer,
 			Volumes:       volumes,
 		}); err != nil {
 			log.Fatalf("failed to run updater: %v", err)

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -54,8 +54,8 @@ type RunParams struct {
 	UpdaterImage string
 	// ProxyImage is the image to use for the proxy
 	ProxyImage string
-	// UseStdout is used to determine if the updater should write to stdout
-	UseStdout bool
+	// Writer is where API calls will be written to
+	Writer    io.Writer
 	InputName string
 	InputRaw  []byte
 }
@@ -75,7 +75,7 @@ func Run(params RunParams) error {
 		cancel()
 	}()
 
-	api := server.NewAPI(params.Expected, params.UseStdout)
+	api := server.NewAPI(params.Expected, params.Writer)
 	defer api.Stop()
 
 	var outFile *os.File

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -48,6 +48,8 @@ type RunParams struct {
 	UpdaterImage string
 	// ProxyImage is the image to use for the proxy
 	ProxyImage string
+	// UseStdout is used to determine if the updater should write to stdout
+	UseStdout bool
 }
 
 func Run(params RunParams) error {
@@ -65,7 +67,7 @@ func Run(params RunParams) error {
 		cancel()
 	}()
 
-	api := server.NewAPI(params.Expected)
+	api := server.NewAPI(params.Expected, params.UseStdout)
 	defer api.Stop()
 
 	var outFile *os.File

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -35,10 +35,11 @@ type API struct {
 	cursor          int
 	hasExpectations bool
 	port            int
+	useStdout       bool
 }
 
 // NewAPI creates a new API instance and starts the server
-func NewAPI(expected []model.Output) *API {
+func NewAPI(expected []model.Output, useStdout bool) *API {
 	fakeAPIHost := "127.0.0.1"
 	if runtime.GOOS == "linux" {
 		fakeAPIHost = "0.0.0.0"
@@ -60,6 +61,7 @@ func NewAPI(expected []model.Output) *API {
 	api := &API{
 		server:          server,
 		Expectations:    expected,
+		useStdout:       useStdout,
 		cursor:          0,
 		hasExpectations: len(expected) > 0,
 		port:            l.Addr().(*net.TCPAddr).Port,
@@ -122,13 +124,15 @@ func (a *API) ServeHTTP(_ http.ResponseWriter, r *http.Request) {
 	}
 
 	if !a.hasExpectations {
-		// output the data received to stdout
-		if err = json.NewEncoder(os.Stdout).Encode(map[string]any{
-			"type": kind,
-			"data": actual.Data,
-		}); err != nil {
-			// Fail so the user knows stdout is not working
-			log.Panicln("Failed to write to stdout: ", err)
+		if a.useStdout {
+			// output the data received to stdout
+			if err = json.NewEncoder(os.Stdout).Encode(map[string]any{
+				"type": kind,
+				"data": actual.Data,
+			}); err != nil {
+				// Fail so the user knows stdout is not working
+				log.Panicln("Failed to write to stdout: ", err)
+			}
 		}
 		return
 	}


### PR DESCRIPTION
This PR restricts the use of stdout added in #78 to the `update` subcommand which was the original intent, but missed the mark.

Also using stdout while debugging messes up the terminal, so I've suppressed it in that case as well. 
