### PR TITLE
fix prefix alignment

### DIFF
--- a/cmd/dependabot/internal/cmd/root.go
+++ b/cmd/dependabot/internal/cmd/root.go
@@ -46,7 +46,7 @@ func Execute() {
 
 func init() {
 	log.SetFlags(log.Ldate | log.Ltime | log.LUTC)
-	log.SetPrefix("cli | ")
+	log.SetPrefix("    cli | ")
 
 	rootCmd.PersistentFlags().StringVar(&updaterImage, "updater-image", "", "container image to use for the updater")
 	rootCmd.PersistentFlags().StringVar(&proxyImage, "proxy-image", infra.ProxyImageName, "container image to use for the proxy")

--- a/internal/infra/proxy.go
+++ b/internal/infra/proxy.go
@@ -158,7 +158,7 @@ func (p *Proxy) TailLogs(ctx context.Context, cli *client.Client) {
 
 	r, w := io.Pipe()
 	go func() {
-		_, _ = io.Copy(os.Stderr, prefixer.New(r, "proxy | "))
+		_, _ = io.Copy(os.Stderr, prefixer.New(r, "  proxy | "))
 	}()
 	_, _ = stdcopy.StdCopy(w, w, out)
 }


### PR DESCRIPTION
This makes the output easier to read.

Before:

```
cli | 2023/04/05 13:55:32 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
cli | 2023/04/05 13:55:32 Adding missing credentials-metadata into job definition
cli | 2023/04/05 13:55:32 using image ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy:latest at sha256:03f32e8b990a3f2def4001771ffcbe2c57c98019763ca7a9166b5aea2a924295
cli | 2023/04/05 13:55:32 using image ghcr.io/dependabot/dependabot-updater-gomod at sha256:dcf6b3ae143e6295bd2e57343bbfbfeb99dbd04726944324436636a2ca228527
proxy | 2023/04/05 13:55:33 proxy starting, commit: 
proxy | 2023/04/05 13:55:33 initializing metrics client: No address passed and autodetection from environment failed
proxy | 2023/04/05 13:55:33 Listening (:1080)
updater | Updating certificates in /etc/ssl/certs...
```

After:

```
    cli | 2023/04/05 13:57:16 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
    cli | 2023/04/05 13:57:16 Adding missing credentials-metadata into job definition
    cli | 2023/04/05 13:57:16 using image ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy:latest at sha256:03f32e8b990a3f2def4001771ffcbe2c57c98019763ca7a9166b5aea2a924295
    cli | 2023/04/05 13:57:16 using image ghcr.io/dependabot/dependabot-updater-gomod at sha256:dcf6b3ae143e6295bd2e57343bbfbfeb99dbd04726944324436636a2ca228527
  proxy | 2023/04/05 13:57:17 proxy starting, commit: 
  proxy | 2023/04/05 13:57:17 initializing metrics client: No address passed and autodetection from environment failed
  proxy | 2023/04/05 13:57:17 Listening (:1080)
updater | Updating certificates in /etc/ssl/certs...
```