### PR TITLE
Introduce dependency-groups

### DIFF
--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -74,6 +74,7 @@ var updateCmd = &cobra.Command{
 				AllowedUpdates: []model.Allowed{{
 					UpdateType: "all",
 				}},
+				DependencyGroups:           nil,
 				Dependencies:               nil,
 				ExistingPullRequests:       [][]model.ExistingPR{},
 				IgnoreConditions:           []model.Condition{},

--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -4,6 +4,7 @@ package model
 type Job struct {
 	PackageManager             string         `json:"package-manager" yaml:"package-manager"`
 	AllowedUpdates             []Allowed      `json:"allowed-updates" yaml:"allowed-updates,omitempty"`
+	DependencyGroups           []Group        `json:"dependency-groups" yaml:"dependency-groups,omitempty"`
 	Dependencies               []string       `json:"dependencies" yaml:"dependencies,omitempty"`
 	ExistingPullRequests       [][]ExistingPR `json:"existing-pull-requests" yaml:"existing-pull-requests,omitempty"`
 	Experiments                Experiment     `json:"experiments" yaml:"experiments,omitempty"`
@@ -43,6 +44,11 @@ type Allowed struct {
 	DependencyType string `json:"dependency-type,omitempty" yaml:"dependency-type,omitempty"`
 	DependencyName string `json:"dependency-name,omitempty" yaml:"dependency-name,omitempty"`
 	UpdateType     string `json:"update-type,omitempty" yaml:"update-type,omitempty"`
+}
+
+type Group struct {
+	GroupName string   `json:"name,omitempty" yaml:"name,omitempty"`
+	Rules     []string `json:"rules,omitempty" yaml:"rules,omitempty"`
 }
 
 type Condition struct {

--- a/internal/model/job_test.go
+++ b/internal/model/job_test.go
@@ -335,6 +335,9 @@ job:
   allowed-updates:
   - dependency-type: direct
     update-type: all
+  dependency-groups:
+  - name: npm
+    rules: ["npm", "@npmcli*"]
   credentials-metadata:
   - type: git_source
     host: github.com


### PR DESCRIPTION
Adds `dependency-groups` to the Updater.

[DependencyGroups](https://github.com/github/dependabot-api/pull/3774/files) (originally named GroupRules) are [stored](https://github.com/github/dependabot-api/commit/78e59eb6ac341726f5c914d4b78013c84ebd312e?diff=unified&w=0#diff-da569d966e6bc3649fafd77bcd72467192ee9102e45c9b02f39c5c1559549ff5R298) in an update config and are [serialized](https://github.com/github/dependabot-api/commit/002357ee77760539dc57607fa936ca8ff49ee257?diff=unified&w=0#diff-4f8dfc1ca07c0097e4bd26f7965a3e1f4b97db41431c415eaf20cdad55c97530R15) in update jobs in the shape of `{ name => [rules] }` where both name and rules are strings.

DependencyGroups are fully optional.

Not sure what else is missing?