### PR TITLE
Fix dependency-groups

### DIFF
--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -47,8 +47,8 @@ type Allowed struct {
 }
 
 type Group struct {
-	GroupName string   `json:"name,omitempty" yaml:"name,omitempty"`
-	Rules     []string `json:"rules,omitempty" yaml:"rules,omitempty"`
+	GroupName string         `json:"name,omitempty" yaml:"name,omitempty"`
+	Rules     map[string]any `json:"rules,omitempty" yaml:"rules,omitempty"`
 }
 
 type Condition struct {

--- a/internal/model/job_test.go
+++ b/internal/model/job_test.go
@@ -337,7 +337,8 @@ job:
     update-type: all
   dependency-groups:
   - name: npm
-    rules: ["npm", "@npmcli*"]
+    rules: 
+      patterns: ["npm", "@npmcli*"]
   credentials-metadata:
   - type: git_source
     host: github.com


### PR DESCRIPTION
The original implementation of dependency-groups for the CLI treats rules as a list of strings.
The [actual](https://github.com/github/dependabot-api/blob/main/spec/models/update_job_spec.rb#L1015) implementation of `dependency-group rules` is a hash where the key is the type of dependency-group and the value is the group's rules.

For now there is only one type of dependency-group that is supported, `patterns`. However, in the future, there may be more types that are supported, so we must specify the type here.

This PR updates dependency-groups so that rules are now of type `map[string]any`. The job test reflects this change by passing in a key/value pair of rules in the form of `patterns: [patterns]`