### PR TITLE
improve handling of input problems

### DIFF
--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -122,8 +122,7 @@ func extractInput(cmd *cobra.Command) (*model.Input, error) {
 	}
 
 	if hasArguments {
-		input, err := readArguments(cmd)
-		return input, err
+		return readArguments(cmd)
 	}
 
 	if hasServer {

--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -130,8 +130,7 @@ func extractInput(cmd *cobra.Command) (*model.Input, error) {
 	}
 
 	if hasStdin {
-		input, err := readStdin()
-		return input, err
+		return readStdin()
 	}
 
 	return nil, fmt.Errorf("requires input as arguments, input file, or stdin")

--- a/cmd/dependabot/internal/cmd/update_test.go
+++ b/cmd/dependabot/internal/cmd/update_test.go
@@ -89,6 +89,7 @@ func Test_extractInput(t *testing.T) {
 	})
 	t.Run("test server", func(t *testing.T) {
 		go func() {
+			// Retry the calls in case the server takes a bit to start up.
 			for i := 0; i < 10; i++ {
 				body := strings.NewReader(`{"job":{"package-manager":"go_modules"}}`)
 				_, err := http.Post("http://127.0.0.1:8080", "application/json", body)

--- a/cmd/dependabot/internal/cmd/update_test.go
+++ b/cmd/dependabot/internal/cmd/update_test.go
@@ -91,7 +91,7 @@ func Test_extractInput(t *testing.T) {
 		go func() {
 			for i := 0; i < 10; i++ {
 				body := strings.NewReader(`{"job":{"package-manager":"go_modules"}}`)
-				_, err := http.Post("http://localhost:8080", "application/json", body)
+				_, err := http.Post("http://127.0.0.1:8080", "application/json", body)
 				if err != nil {
 					time.Sleep(10 * time.Millisecond)
 				} else {

--- a/cmd/dependabot/internal/cmd/update_test.go
+++ b/cmd/dependabot/internal/cmd/update_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func Test_processInput(t *testing.T) {
@@ -88,8 +89,15 @@ func Test_extractInput(t *testing.T) {
 	})
 	t.Run("test server", func(t *testing.T) {
 		go func() {
-			body := strings.NewReader(`{"job":{"package-manager":"go_modules"}}`)
-			_, _ = http.Post("http://localhost:8080", "application/json", body)
+			for i := 0; i < 10; i++ {
+				body := strings.NewReader(`{"job":{"package-manager":"go_modules"}}`)
+				_, err := http.Post("http://localhost:8080", "application/json", body)
+				if err != nil {
+					time.Sleep(10 * time.Millisecond)
+				} else {
+					return
+				}
+			}
 		}()
 
 		cmd := NewUpdateCommand()

--- a/internal/server/input.go
+++ b/internal/server/input.go
@@ -29,7 +29,7 @@ func (s *credServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // Input receives configuration via HTTP on the port and returns it decoded
-func Input(port int) *model.Input {
+func Input(port int) (*model.Input, error) {
 	server := &http.Server{
 		Addr:              fmt.Sprintf("127.0.0.1:%d", port),
 		ReadHeaderTimeout: time.Second,
@@ -39,7 +39,7 @@ func Input(port int) *model.Input {
 	// printing so the user doesn't think the cli is hanging
 	log.Println("waiting for input on port", port)
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		panic(err)
+		return nil, err
 	}
-	return s.data
+	return s.data, nil
 }

--- a/internal/server/input_test.go
+++ b/internal/server/input_test.go
@@ -14,7 +14,7 @@ func TestInput(t *testing.T) {
 	wg.Add(1)
 	var input *model.Input
 	go func() {
-		input = Input(8080)
+		input, _ = Input(8080)
 		wg.Done()
 	}()
 

--- a/testdata/basic.yml
+++ b/testdata/basic.yml
@@ -1,0 +1,9 @@
+job:
+  package-manager: go_modules
+  allowed-updates:
+    - dependency-type: direct
+      update-type: all
+  source:
+    provider: github
+    repo: rsc/quote
+    directory: /


### PR DESCRIPTION
There were some cases where the CLI would not be helpful:
- `dependabot update` would run an update with no input at all, and fail since package_manger isn't set
- `dependabot update cargo` panics
- Possibly some other cases

This fixes it by ensuring one form of input was provided. 

I suggest looking at 7ec336745bd0360b9e72559ebf1dd8bbb1a59d5c before I broke out the function.