### PR TITLE
Teach CreatePullRequest about the dependency-group key, remove grouped-update key

### DIFF
--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -16,7 +16,7 @@ type CreatePullRequest struct {
 	PRTitle                string           `json:"pr-title" yaml:"pr-title,omitempty"`
 	PRBody                 string           `json:"pr-body" yaml:"pr-body,omitempty"`
 	CommitMessage          string           `json:"commit-message" yaml:"commit-message,omitempty"`
-	GroupedUpdate          bool             `json:"grouped-update" yaml:"grouped-update"`
+	DependencyGroup        map[string]any   `json:"dependency-group" yaml:"dependency-group"`
 }
 
 type UpdatePullRequest struct {


### PR DESCRIPTION
Grouped updates now pass in the name of the group the PR was created with instead of a boolean grouped-update flag

/xref https://github.com/dependabot/dependabot-core/pull/7166