### PR TITLE
DependencyGroup should be omitted if empty, can also be present in Updates

### DIFF
--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -16,7 +16,7 @@ type CreatePullRequest struct {
 	PRTitle                string           `json:"pr-title" yaml:"pr-title,omitempty"`
 	PRBody                 string           `json:"pr-body" yaml:"pr-body,omitempty"`
 	CommitMessage          string           `json:"commit-message" yaml:"commit-message,omitempty"`
-	DependencyGroup        map[string]any   `json:"dependency-group" yaml:"dependency-group"`
+	DependencyGroup        map[string]any   `json:"dependency-group" yaml:"dependency-group,omitempty"`
 }
 
 type UpdatePullRequest struct {
@@ -26,6 +26,7 @@ type UpdatePullRequest struct {
 	PRTitle                string           `json:"pr-title" yaml:"pr-title,omitempty"`
 	PRBody                 string           `json:"pr-body" yaml:"pr-body,omitempty"`
 	CommitMessage          string           `json:"commit-message" yaml:"commit-message,omitempty"`
+	DependencyGroup        map[string]any   `json:"dependency-group" yaml:"dependency-group,omitempty"`
 }
 
 type DependencyFile struct {


### PR DESCRIPTION
Follow up on conversation in https://github.com/dependabot/cli/pull/102

We don't [send this key if it doesn't apply](https://github.com/dependabot/dependabot-core/pull/7166/files#diff-1f8c3901647148d6f9fbda3a5c943490beb28c1291f21a3b6713471e0c39902bR169-R176), so `omitempty` is most correct.

I've also added it to `UpdatePullRequest` since we'll need to start sending it optionally in that payload soon™️, so this will avoid releasing another version later.