### PR TITLE
Add DependencyGroupToRefresh and ExistingGroupPullRequests to the Job model

### DIFF
--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -26,25 +26,27 @@ reasons.
 
 // Job is the data that is passed to the updater.
 type Job struct {
-	PackageManager             string         `json:"package-manager" yaml:"package-manager"`
-	AllowedUpdates             []Allowed      `json:"allowed-updates" yaml:"allowed-updates,omitempty"`
-	DependencyGroups           []Group        `json:"dependency-groups" yaml:"dependency-groups,omitempty"`
-	Dependencies               []string       `json:"dependencies" yaml:"dependencies,omitempty"`
-	ExistingPullRequests       [][]ExistingPR `json:"existing-pull-requests" yaml:"existing-pull-requests,omitempty"`
-	Experiments                Experiment     `json:"experiments" yaml:"experiments,omitempty"`
-	IgnoreConditions           []Condition    `json:"ignore-conditions" yaml:"ignore-conditions,omitempty"`
-	LockfileOnly               bool           `json:"lockfile-only" yaml:"lockfile-only,omitempty"`
-	RequirementsUpdateStrategy *string        `json:"requirements-update-strategy" yaml:"requirements-update-strategy,omitempty"`
-	SecurityAdvisories         []Advisory     `json:"security-advisories" yaml:"security-advisories,omitempty"`
-	SecurityUpdatesOnly        bool           `json:"security-updates-only" yaml:"security-updates-only,omitempty"`
-	Source                     Source         `json:"source" yaml:"source"`
-	UpdateSubdependencies      bool           `json:"update-subdependencies" yaml:"update-subdependencies,omitempty"`
-	UpdatingAPullRequest       bool           `json:"updating-a-pull-request" yaml:"updating-a-pull-request,omitempty"`
-	VendorDependencies         bool           `json:"vendor-dependencies" yaml:"vendor-dependencies,omitempty"`
-	RejectExternalCode         bool           `json:"reject-external-code" yaml:"reject-external-code,omitempty"`
-	CommitMessageOptions       *CommitOptions `json:"commit-message-options" yaml:"commit-message-options,omitempty"`
-	CredentialsMetadata        []Credential   `json:"credentials-metadata" yaml:"credentials-metadata,omitempty"`
-	MaxUpdaterRunTime          int            `json:"max-updater-run-time" yaml:"max-updater-run-time,omitempty"`
+	PackageManager             string            `json:"package-manager" yaml:"package-manager"`
+	AllowedUpdates             []Allowed         `json:"allowed-updates" yaml:"allowed-updates,omitempty"`
+	DependencyGroups           []Group           `json:"dependency-groups" yaml:"dependency-groups,omitempty"`
+	Dependencies               []string          `json:"dependencies" yaml:"dependencies,omitempty"`
+	DependencyGroupToRefresh   string            `json:"dependency-group-to-refresh" yaml:"dependency-group-to-refresh,omitempty"`
+	ExistingPullRequests       [][]ExistingPR    `json:"existing-pull-requests" yaml:"existing-pull-requests,omitempty"`
+	ExistingGroupPullRequests  []ExistingGroupPR `json:"existing-group-pull-requests" yaml:"existing-group-pull-requests,omitempty"`
+	Experiments                Experiment        `json:"experiments" yaml:"experiments,omitempty"`
+	IgnoreConditions           []Condition       `json:"ignore-conditions" yaml:"ignore-conditions,omitempty"`
+	LockfileOnly               bool              `json:"lockfile-only" yaml:"lockfile-only,omitempty"`
+	RequirementsUpdateStrategy *string           `json:"requirements-update-strategy" yaml:"requirements-update-strategy,omitempty"`
+	SecurityAdvisories         []Advisory        `json:"security-advisories" yaml:"security-advisories,omitempty"`
+	SecurityUpdatesOnly        bool              `json:"security-updates-only" yaml:"security-updates-only,omitempty"`
+	Source                     Source            `json:"source" yaml:"source"`
+	UpdateSubdependencies      bool              `json:"update-subdependencies" yaml:"update-subdependencies,omitempty"`
+	UpdatingAPullRequest       bool              `json:"updating-a-pull-request" yaml:"updating-a-pull-request,omitempty"`
+	VendorDependencies         bool              `json:"vendor-dependencies" yaml:"vendor-dependencies,omitempty"`
+	RejectExternalCode         bool              `json:"reject-external-code" yaml:"reject-external-code,omitempty"`
+	CommitMessageOptions       *CommitOptions    `json:"commit-message-options" yaml:"commit-message-options,omitempty"`
+	CredentialsMetadata        []Credential      `json:"credentials-metadata" yaml:"credentials-metadata,omitempty"`
+	MaxUpdaterRunTime          int               `json:"max-updater-run-time" yaml:"max-updater-run-time,omitempty"`
 }
 
 // Source is a reference to some source code
@@ -62,6 +64,11 @@ type Source struct {
 type ExistingPR struct {
 	DependencyName    string `json:"dependency-name" yaml:"dependency-name"`
 	DependencyVersion string `json:"dependency-version" yaml:"dependency-version"`
+}
+
+type ExistingGroupPR struct {
+	DependencyGroupName string       `json:"dependency-group-name" yaml:"dependency-group-name"`
+	Dependencies        []ExistingPR `json:"dependencies" yaml:"dependencies"`
 }
 
 type Allowed struct {


### PR DESCRIPTION
See: https://github.com/dependabot/dependabot-core/pull/7192

This implements new optional attributes for the Job definition keys introduced to support refreshing Group Update PRs.

An example payload can be seen [here](https://github.com/dependabot/dependabot-core/blob/9faebe9751245ea96a801007d86b96264eecd027/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh.yaml).