### PR TITLE
Add repo-private attribute to job

### DIFF
--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -44,6 +44,7 @@ type Job struct {
 	UpdatingAPullRequest       bool              `json:"updating-a-pull-request" yaml:"updating-a-pull-request,omitempty"`
 	VendorDependencies         bool              `json:"vendor-dependencies" yaml:"vendor-dependencies,omitempty"`
 	RejectExternalCode         bool              `json:"reject-external-code" yaml:"reject-external-code,omitempty"`
+	RepoPrivate                bool              `json:"repo-private" yaml:"repo-private,omitempty"`
 	CommitMessageOptions       *CommitOptions    `json:"commit-message-options" yaml:"commit-message-options,omitempty"`
 	CredentialsMetadata        []Credential      `json:"credentials-metadata" yaml:"credentials-metadata,omitempty"`
 	MaxUpdaterRunTime          int               `json:"max-updater-run-time" yaml:"max-updater-run-time,omitempty"`

--- a/internal/model/job_test.go
+++ b/internal/model/job_test.go
@@ -92,7 +92,7 @@ job:
     provider: github
     repo: dependabot/dependabot-core
     directory: "/npm_and_yarn/helpers"
-    branch: 
+    branch:
     api-endpoint: https://api.github.com/
     hostname: github.com
   dependencies:
@@ -323,21 +323,21 @@ job:
   update-subdependencies: false
   ignore-conditions:
   - dependency-name: npm
-    version-requirement: 
+    version-requirement:
     update-types:
     - version-update:semver-major
     source: ".github/dependabot.yml"
   - dependency-name: npm
     version-requirement: ">= 7.a, < 8"
-    update-types: 
+    update-types:
     source: "@dependabot ignore command"
-  requirements-update-strategy: 
+  requirements-update-strategy:
   allowed-updates:
   - dependency-type: direct
     update-type: all
   dependency-groups:
   - name: npm
-    rules: 
+    rules:
       patterns: ["npm", "@npmcli*"]
   credentials-metadata:
   - type: git_source
@@ -357,8 +357,9 @@ job:
     npm-transitive-security-updates: true
   reject-external-code: false
   commit-message-options:
-    prefix: 
-    prefix-development: 
-    include-scope: 
+    prefix:
+    prefix-development:
+    include-scope:
   security-updates-only: true
+  repo-private: false
 `


### PR DESCRIPTION
This is a new attribute that we can use to improve our observability internally at GitHub.