### PR TITLE
add missing dependency_file field

### DIFF
--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -37,6 +37,7 @@ type DependencyFile struct {
 	Name            string `json:"name" yaml:"name"`
 	Operation       string `json:"operation" yaml:"operation"`
 	SupportFile     bool   `json:"support_file" yaml:"support_file"`
+	SymlinkTarget   string `json:"symlink_target,omitempty" yaml:"symlink_target,omitempty"`
 	Type            string `json:"type" yaml:"type"`
 	Mode            string `json:"mode" yaml:"mode,omitempty"`
 }


### PR DESCRIPTION
symlink_target is a member of dependency_file

Due to the way it's added [here](https://github.com/dependabot/dependabot-core/blob/2240c9797aa46128974e1c11cf7de6bb2d6287df/common/lib/dependabot/dependency_file.rb#L69) only if it exists, I'm adding `omitempty` to the marshal tags.