### PR TITLE
Add the Debug flag to the Job model

### DIFF
--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -28,6 +28,7 @@ reasons.
 type Job struct {
 	PackageManager             string            `json:"package-manager" yaml:"package-manager"`
 	AllowedUpdates             []Allowed         `json:"allowed-updates" yaml:"allowed-updates,omitempty"`
+	Debug                      bool              `json:"debug" yaml:"debug,omitempty"`
 	DependencyGroups           []Group           `json:"dependency-groups" yaml:"dependency-groups,omitempty"`
 	Dependencies               []string          `json:"dependencies" yaml:"dependencies,omitempty"`
 	DependencyGroupToRefresh   string            `json:"dependency-group-to-refresh" yaml:"dependency-group-to-refresh,omitempty"`


### PR DESCRIPTION
We're slowly starting to add the debug log level in the Updater, so let's add this flag so we can turn it on from the job definition file in the CLI.