### PR TITLE
fix release Action permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ jobs:
   releases-matrix:
     name: Release Go Binary
     runs-on: ubuntu-latest
+    permissions:
+        contents: write
+        packages: write
     strategy:
       matrix:
         goos: [linux, windows, darwin]


### PR DESCRIPTION
Due to recent permission changes on the default token, we need to specify what permissions this Action has to create the release artifacts.