### PR TITLE
implement commit and dep arguments

### DIFF
--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -90,7 +90,7 @@ func NewUpdateCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&provider, "provider", "p", "github", "provider of the repository")
 	cmd.Flags().StringVarP(&directory, "directory", "d", "/", "directory to update")
 	cmd.Flags().StringVarP(&commit, "commit", "", "", "commit to update")
-	cmd.Flags().StringArrayVarP(&dependencies, "dep", "", nil, "dependency to update")
+	cmd.Flags().StringArrayVarP(&dependencies, "dep", "", nil, "dependencies to update")
 
 	cmd.Flags().StringVarP(&output, "output", "o", "", "write scenario to file")
 	cmd.Flags().StringVar(&cache, "cache", "", "cache import/export directory")


### PR DESCRIPTION
fixes #137 @deivid-rodriguez 

Adds more convenient arguments to the CLI that we already have in the dry-run.rb script.

I used `allowed-updates` to implement the dep feature, as the dry-run script actually parses the manifest and then filters the results. We can't do that here, but allowed updates is basically the same thing.

```console
$ dependabot update go_modules dependabot/cli --dep github.com/docker/cli --commit 476dbb9d51853b129a3f8a21f82d1c3c7001e881
...
updater | +-------------------------------------------------------------------------------------+
updater | |                         Changes to Dependabot Pull Requests                         |
updater | +---------+---------------------------------------------------------------------------+
updater | | created | github.com/docker/cli ( from 24.0.1+incompatible to 24.0.2+incompatible ) |
updater | +---------+---------------------------------------------------------------------------+
```