### PR TITLE
fix: add missing python package manager lookup

### DIFF
--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -226,6 +226,7 @@ var packageManagerLookup = map[string]string{
 	"hex":            "mix",
 	"nuget":          "nuget",
 	"npm_and_yarn":   "npm",
+	"python":         "pip",
 	"pip":            "pip",
 	"terraform":      "terraform",
 }


### PR DESCRIPTION
I receive a ` failed to run updater: unknown package manager: python` when I try to use the `python` package manager argument given in [the documentation](https://github.com/dependabot/cli#dependabot-update). By inspecting the codebase, I noticed that the CLI works with `pip`. This pull requests maps `python` to `pip. 

#### Comments

- Alternatively, we can update the documentation.
- We can also remove the `pip` mapping key to be consistent with the documentation. I now left it for back compatibility, but if we leave it, we can also add the `gomod` key.