### PR TITLE
Migrate `RecordPackageManagerVersion` to `RecordEcosystemVersions`

### DIFF
--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -51,7 +51,7 @@ type MarkAsProcessed struct {
 	BaseCommitSha string `json:"base-commit-sha" yaml:"base-commit-sha"`
 }
 
-type RecordPackageManagerVersion struct {
+type RecordEcosystemVersions struct {
 	Ecosystem       string         `json:"ecosystem" yaml:"ecosystem"`
 	PackageManagers map[string]any `json:"package-managers" yaml:"package-managers"`
 }

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -223,8 +223,8 @@ func decodeWrapper(kind string, data []byte) (actual *model.UpdateWrapper, err e
 		actual.Data, err = decode[model.ClosePullRequest](data)
 	case "mark_as_processed":
 		actual.Data, err = decode[model.MarkAsProcessed](data)
-	case "record_package_manager_version":
-		actual.Data, err = decode[model.RecordPackageManagerVersion](data)
+	case "record_ecosystem_versions":
+		actual.Data, err = decode[model.RecordEcosystemVersions](data)
 	case "record_update_job_error":
 		actual.Data, err = decode[model.RecordUpdateJobError](data)
 	case "increment_metric":
@@ -273,8 +273,8 @@ func compare(expect, actual *model.UpdateWrapper) error {
 		return compareUpdatePullRequest(v, actual.Data.(model.UpdatePullRequest))
 	case model.ClosePullRequest:
 		return compareClosePullRequest(v, actual.Data.(model.ClosePullRequest))
-	case model.RecordPackageManagerVersion:
-		return compareRecordPackageManagerVersion(v, actual.Data.(model.RecordPackageManagerVersion))
+	case model.RecordEcosystemVersions:
+		return compareRecordEcosystemVersions(v, actual.Data.(model.RecordEcosystemVersions))
 	case model.MarkAsProcessed:
 		return compareMarkAsProcessed(v, actual.Data.(model.MarkAsProcessed))
 	case model.RecordUpdateJobError:
@@ -316,11 +316,11 @@ func compareClosePullRequest(expect, actual model.ClosePullRequest) error {
 	return unexpectedBody("close_pull_request")
 }
 
-func compareRecordPackageManagerVersion(expect, actual model.RecordPackageManagerVersion) error {
+func compareRecordEcosystemVersions(expect, actual model.RecordEcosystemVersions) error {
 	if reflect.DeepEqual(expect, actual) {
 		return nil
 	}
-	return unexpectedBody("record_package_manager_version")
+	return unexpectedBody("record_ecosystem_versions")
 }
 
 func compareMarkAsProcessed(expect, actual model.MarkAsProcessed) error {


### PR DESCRIPTION
This endpoint was renamed in https://github.com/dependabot/dependabot-core/pull/7517 and the accompanying internal API change.

So the mock here needs updating. Also updated the struct.

Note that the smoke tests will not pass until they are also updated... but we're in a chicken-and-egg because they currently blow up because this endpoint isn't mocked.