### PR TITLE
The `package-managers` field is now optional

### DIFF
--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -53,7 +53,7 @@ type MarkAsProcessed struct {
 
 type RecordEcosystemVersions struct {
 	Ecosystem       string         `json:"ecosystem" yaml:"ecosystem"`
-	PackageManagers map[string]any `json:"package-managers" yaml:"package-managers"`
+	PackageManagers map[string]any `json:"package-managers,omitempty" yaml:"package-managers,omitempty"`
 }
 
 type RecordUpdateJobError struct {


### PR DESCRIPTION
The reason I switched us from `record_package_manager_version` to `record_ecosystem_versions` is that we want to start recording the language runtime version as well.

There may be situations where we have instrumented the language but not the package manager version.

In those cases, this field will be empty, so make it optional.

Related:
* https://github.com/dependabot/cli/pull/145