### PR TITLE
`ecosystem_versions` replaces `package_manager` field

### DIFF
--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -52,8 +52,7 @@ type MarkAsProcessed struct {
 }
 
 type RecordEcosystemVersions struct {
-	Ecosystem       string         `json:"ecosystem" yaml:"ecosystem"`
-	PackageManagers map[string]any `json:"package-managers,omitempty" yaml:"package-managers,omitempty"`
+	EcosystemVersions map[string]any `json:"ecosystem_versions" yaml:"ecosystem_versions"`
 }
 
 type RecordUpdateJobError struct {


### PR DESCRIPTION
I confused myself in the previous two PR's... the `Ecosystem` field is actually removed, and the `PackageManager` field is replaced by the `EcosystemVersions` field.

As explained in https://github.com/dependabot/cli/pull/146, there may
be an inner `PackageManager` field, which is optional. But no need to
map it out in the struct, at least not yet.

For background context:
* https://github.com/dependabot/cli/pull/145
* https://github.com/dependabot/cli/pull/146
* https://github.com/dependabot/dependabot-core/pull/7492
* https://github.com/dependabot/dependabot-core/pull/7517

Caught this discrepancy over here:
* https://github.com/dependabot/smoke-tests/pull/98/files#r1260099204