### PR TITLE
fix the release workflow trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release binary builder
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   releases-matrix:


### PR DESCRIPTION
We're noticing that the `created` event doesn't fire if you save a draft release, and then publish it. Here's the docs for relevant release type events:

1. created - A draft was saved, or a release or pre-release was published without previously being saved as a draft.
2. prereleased - A release was created and identified as a pre-release. A pre-release is a release that is not ready for production and may be unstable.
3. published - A release, pre-release, or draft of a release was published.
4. released - A release was published, or a pre-release was changed to a release.

I'm going with `published` since it will also cover pre-release if we start to use it for some reason.