### PR TITLE
fix credential access check to work with GHES

### DIFF
--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -93,7 +93,7 @@ func Run(params RunParams) error {
 	}
 
 	expandEnvironmentVariables(api, &params)
-	if err := checkCredAccess(ctx, params.Creds); err != nil {
+	if err := checkCredAccess(ctx, params.Job, params.Creds); err != nil {
 		return err
 	}
 
@@ -170,15 +170,15 @@ func diff(params RunParams, outFile *os.File, output []byte) error {
 }
 
 var (
-	authEndpoint   = "https://api.github.com"
-	ErrWriteAccess = fmt.Errorf("for security, credentials used in update are not allowed to have write access to GitHub API")
+	defaultApiEndpoint = "https://api.github.com"
+	ErrWriteAccess     = fmt.Errorf("for security, credentials used in update are not allowed to have write access to GitHub API")
 )
 
 // checkCredAccess returns an error if any of the tokens in the job definition have write access.
 // Some package managers can execute arbitrary code during an update. The credentials are not accessible to the updater,
 // but the proxy injects them in requests, and the updater could execute arbitrary requests. So to be safe, disallow
 // write access on these tokens.
-func checkCredAccess(ctx context.Context, creds []model.Credential) error {
+func checkCredAccess(ctx context.Context, job *model.Job, creds []model.Credential) error {
 	for _, cred := range creds {
 		var credential string
 		if password, ok := cred["password"]; ok && password != "" {
@@ -190,7 +190,11 @@ func checkCredAccess(ctx context.Context, creds []model.Credential) error {
 		if !strings.HasPrefix(credential, "ghp_") {
 			continue
 		}
-		r, err := http.NewRequestWithContext(ctx, "GET", authEndpoint, http.NoBody)
+		apiEndpoint := defaultApiEndpoint
+		if job != nil && job.Source.APIEndpoint != nil && *job.Source.APIEndpoint != "" {
+			apiEndpoint = *job.Source.APIEndpoint
+		}
+		r, err := http.NewRequestWithContext(ctx, "GET", apiEndpoint, http.NoBody)
 		if err != nil {
 			return fmt.Errorf("failed creating request: %w", err)
 		}
@@ -201,7 +205,7 @@ func checkCredAccess(ctx context.Context, creds []model.Credential) error {
 			return fmt.Errorf("failed making request: %w", err)
 		}
 		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("failed request to GitHub API: %s", resp.Status)
+			return fmt.Errorf("failed request to GitHub API to check access: %s", resp.Status)
 		}
 		scopes := resp.Header.Get("X-OAuth-Scopes")
 		if strings.Contains(scopes, "write") || strings.Contains(scopes, "delete") {


### PR DESCRIPTION
fix #153

The credential write access check was hardcoded to use api.github.com but that prevents it from working with GItHub Enterprise. 

This change uses the API endpoint defined in the input file if it's present, otherwise falls back to api.github.com. 