### PR TITLE
fix moby regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.20.6
 
       - name: Build
         run: go build -v ./...
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.20.6
 
       - name: Run go vet
         run: go vet ./...
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.20.6
 
       - name: Run integration tests
         run: tests/local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.6
+          go-version: 1.20.5
 
       - name: Build
         run: go build -v ./...
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.6
+          go-version: 1.20.5
 
       - name: Run go vet
         run: go vet ./...
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.6
+          go-version: 1.20.5
 
       - name: Run integration tests
         run: tests/local

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: wangyoucao577/go-release-action@v1.38
         with:
-          goversion: 1.20.6
+          goversion: 1.20.5
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: wangyoucao577/go-release-action@v1.38
         with:
-          goversion: 1.19
+          goversion: 1.20.6
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.20.6
 
       # Download the Proxy cache. The job is ideally 100% cached so no real calls are made.
       - name: Download cache

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.6
+          go-version: 1.20.5
 
       # Download the Proxy cache. The job is ideally 100% cached so no real calls are made.
       - name: Download cache

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dependabot/cli
 
-go 1.19
+go 1.20
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0

--- a/internal/infra/run_test.go
+++ b/internal/infra/run_test.go
@@ -225,7 +225,7 @@ func TestRun(t *testing.T) {
 }
 
 const dockerFile = `
-FROM golang:1.20.6
+FROM golang:1.20.5
 
 # needed to run update-ca-certificates
 RUN apt-get update && apt-get install -y ca-certificates

--- a/internal/infra/run_test.go
+++ b/internal/infra/run_test.go
@@ -225,7 +225,7 @@ func TestRun(t *testing.T) {
 }
 
 const dockerFile = `
-FROM golang:1.19
+FROM golang:1.20.6
 
 # needed to run update-ca-certificates
 RUN apt-get update && apt-get install -y ca-certificates


### PR DESCRIPTION
There's a [bug](https://github.com/docker/cli/issues/4437) in the the moby library with the latest Go 1.19 and 1.20 releases. Fixing it by pinning to the previous patch. I've updated to Go 1.20 while I was at it. 