### PR TITLE
need null value on dependency-group-to-refresh

### DIFF
--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -31,7 +31,7 @@ type Job struct {
 	Debug                      bool              `json:"debug" yaml:"debug,omitempty"`
 	DependencyGroups           []Group           `json:"dependency-groups" yaml:"dependency-groups,omitempty"`
 	Dependencies               []string          `json:"dependencies" yaml:"dependencies,omitempty"`
-	DependencyGroupToRefresh   string            `json:"dependency-group-to-refresh" yaml:"dependency-group-to-refresh,omitempty"`
+	DependencyGroupToRefresh   *string           `json:"dependency-group-to-refresh" yaml:"dependency-group-to-refresh,omitempty"`
 	ExistingPullRequests       [][]ExistingPR    `json:"existing-pull-requests" yaml:"existing-pull-requests,omitempty"`
 	ExistingGroupPullRequests  []ExistingGroupPR `json:"existing-group-pull-requests" yaml:"existing-group-pull-requests,omitempty"`
 	Experiments                Experiment        `json:"experiments" yaml:"experiments,omitempty"`


### PR DESCRIPTION
The Ruby code uses a nil value as a signal, but Go will interpret it as the empty string value unless you use a pointer.