### PR TITLE
Document how to use `go install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,19 @@ The `dependabot` CLI is a tool for testing and debugging Dependabot update jobs.
 
 ## Installation
 
-You can download a pre-built binary from the [releases] page.
+Use any of the following for a pain-free installation:
 
-If you have the [`gh`][gh] command available,
-you can install the latest release of `dependabot` using the following command
-([gist source](https://gist.github.com/mattt/e09e1ecd76d5573e0517a7622009f06f)):
-
-```console
-gh gist view --raw e09e1ecd76d5573e0517a7622009f06f | bash
-```
+* If you have [`go`](https://go.dev/doc/install) installed, you can run:
+   ```shell
+   go install github.com/dependabot/cli/cmd/dependabot@latest
+   ```
+   The benefit of this method is that re-running the command will always update to the latest version.
+* You can download a pre-built binary from the [releases] page.
+* If you have the [`gh`][gh] command available, you can install the latest release
+   of `dependabot` using the following command ([gist source](https://gist.github.com/mattt/e09e1ecd76d5573e0517a7622009f06f)):
+   ```shell
+   gh gist view --raw e09e1ecd76d5573e0517a7622009f06f | bash
+   ```
 
 ## Requirements
 


### PR DESCRIPTION
This is often more convenient then manually downloading the binary because it's so simple and the command doesn't change between initial install / later upgrades.