### PR TITLE
fix proxy hostname unresolvable in k8s

### DIFF
--- a/internal/infra/proxy.go
+++ b/internal/infra/proxy.go
@@ -4,43 +4,34 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/goware/prefixer"
-	"io"
-	"math/rand"
-	"os"
-	"path"
-	"path/filepath"
-	"strings"
-	"time"
-
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
+	"github.com/goware/prefixer"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/pkg/namesgenerator"
 	"github.com/moby/moby/pkg/stdcopy"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
 )
 
 const proxyCertPath = "/usr/local/share/ca-certificates/custom-ca-cert.crt"
-
-func init() {
-	// needed for namesgenerator.GetRandomName
-	rand.Seed(time.Now().UnixNano())
-}
 
 // ProxyImageName is the default Docker image used by the proxy
 const ProxyImageName = "ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy:latest"
 
 type Proxy struct {
-	cli           *client.Client
-	containerID   string
-	containerName string
-	url           string
-	ca            CertificateAuthority
+	cli         *client.Client
+	containerID string
+	url         string
+	ca          CertificateAuthority
 }
 
-func NewProxy(ctx context.Context, cli *client.Client, params *RunParams, nets ...types.NetworkCreateResponse) (*Proxy, error) {
+func NewProxy(ctx context.Context, cli *client.Client, params *RunParams, nets *Networks) (*Proxy, error) {
 	// Generate secrets:
 	ca, err := GenerateCertificateAuthority()
 	if err != nil {
@@ -104,11 +95,9 @@ func NewProxy(ctx context.Context, cli *client.Client, params *RunParams, nets .
 	}
 
 	proxy := &Proxy{
-		cli:           cli,
-		containerID:   proxyContainer.ID,
-		containerName: hostName,
-		url:           fmt.Sprintf("http://%s:1080", hostName),
-		ca:            ca,
+		cli:         cli,
+		containerID: proxyContainer.ID,
+		ca:          ca,
 	}
 
 	if err = putProxyConfig(ctx, cli, proxyConfig, proxyContainer.ID); err != nil {
@@ -116,10 +105,15 @@ func NewProxy(ctx context.Context, cli *client.Client, params *RunParams, nets .
 		return nil, fmt.Errorf("failed to connect to network: %w", err)
 	}
 
-	for _, n := range nets {
-		if err = cli.NetworkConnect(ctx, n.ID, proxyContainer.ID, &network.EndpointSettings{}); err != nil {
+	// nil check since tests don't always need networks
+	if nets != nil {
+		if err = cli.NetworkConnect(ctx, nets.NoInternet.ID, proxyContainer.ID, &network.EndpointSettings{}); err != nil {
 			_ = proxy.Close()
-			return nil, fmt.Errorf("failed to connect to network: %w", err)
+			return nil, fmt.Errorf("failed to connect to internal network: %w", err)
+		}
+		if err = cli.NetworkConnect(ctx, nets.Internet.ID, proxyContainer.ID, &network.EndpointSettings{}); err != nil {
+			_ = proxy.Close()
+			return nil, fmt.Errorf("failed to connect to external network: %w", err)
 		}
 	}
 
@@ -127,6 +121,12 @@ func NewProxy(ctx context.Context, cli *client.Client, params *RunParams, nets .
 		_ = proxy.Close()
 		return nil, fmt.Errorf("failed to start container: %w", err)
 	}
+
+	containerInfo, err := cli.ContainerInspect(ctx, proxyContainer.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect proxy container: %w", err)
+	}
+	proxy.url = fmt.Sprintf("http://%s:1080", containerInfo.NetworkSettings.Networks[nets.noInternetName].IPAddress)
 
 	return proxy, nil
 }

--- a/internal/infra/proxy.go
+++ b/internal/infra/proxy.go
@@ -13,6 +13,7 @@ import (
 	"github.com/moby/moby/pkg/namesgenerator"
 	"github.com/moby/moby/pkg/stdcopy"
 	"io"
+	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -126,7 +127,12 @@ func NewProxy(ctx context.Context, cli *client.Client, params *RunParams, nets *
 	if err != nil {
 		return nil, fmt.Errorf("failed to inspect proxy container: %w", err)
 	}
-	proxy.url = fmt.Sprintf("http://%s:1080", containerInfo.NetworkSettings.Networks[nets.noInternetName].IPAddress)
+	if nets != nil {
+		proxy.url = fmt.Sprintf("http://%s:1080", containerInfo.NetworkSettings.Networks[nets.noInternetName].IPAddress)
+	} else {
+		// This should only happen during testing, adding a warning in case
+		log.Println("Warning: no-internet network not found")
+	}
 
 	return proxy, nil
 }

--- a/internal/infra/proxy_test.go
+++ b/internal/infra/proxy_test.go
@@ -13,17 +13,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/moby/moby/client"
-	"github.com/moby/moby/pkg/namesgenerator"
 )
-
-func TestSeed(t *testing.T) {
-	// ensure we're still seeding
-	a := namesgenerator.GetRandomName(1)
-	b := namesgenerator.GetRandomName(1)
-	if a == b {
-		t.Error("Not seeding math/rand")
-	}
-}
 
 // This tests the Proxy's ability to use a custom cert for outbound calls.
 // It creates a custom proxy image to test with, passes it a cert, and uses it to
@@ -97,7 +87,7 @@ func TestNewProxy_customCert(t *testing.T) {
 	proxy, err := NewProxy(ctx, cli, &RunParams{
 		ProxyCertPath: cert.Name(),
 		ProxyImage:    proxyImageName,
-	})
+	}, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -321,7 +321,7 @@ func runContainers(ctx context.Context, params RunParams, api *server.API) error
 	}
 	defer networks.Close()
 
-	prox, err := NewProxy(ctx, cli, &params, networks.NoInternet, networks.Internet)
+	prox, err := NewProxy(ctx, cli, &params, networks)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
probably fixes #159

This implements the same fix @mctofu linked to in https://github.com/github/dependabot-action/pull/136

Also removed `rand.Seed` because rand is automatically seeded since Go 1.20.