### PR TITLE
fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: wangyoucao577/go-release-action@v1.39
         with:
-          goversion: 1.21
+          goversion: 1.21.0 # needs the patch specified
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}


### PR DESCRIPTION
This needs the patch specified because it builds a URL with the version. It was removed in https://github.com/dependabot/cli/pull/164.