### PR TITLE
Improve the `go test` invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
         run: go build -v ./...
 
       - name: Test
-        run: go test ./...
+        # -count=2 ensures that test fixtures cleanup after themselves
+        # because any leftover state will generally cause the second run to fail.
+        run: go test -shuffle=on -count=2 -race -cover -v ./...
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
1. Enable the `race` detector
2. `shuffle` to ensure random ordering
3. `count=2` is very effective at sniffing out global state that doesn't get reset properly by a test.