### PR TITLE
fix updater confused by blank commit

### DIFF
--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -198,7 +198,7 @@ func readArguments(cmd *cobra.Command) (*model.Input, error) {
 				Provider:    provider,
 				Repo:        repo,
 				Directory:   directory,
-				Commit:      &commit,
+				Commit:      commit,
 				Branch:      nil,
 				Hostname:    nil,
 				APIEndpoint: nil,

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -69,7 +69,7 @@ func (p *RunParams) Validate() error {
 	if p.Job == nil {
 		return fmt.Errorf("job is required")
 	}
-	if p.Job.Source.Commit != nil && *p.Job.Source.Commit != "" && !gitShaRegex.MatchString(*p.Job.Source.Commit) {
+	if p.Job.Source.Commit != "" && !gitShaRegex.MatchString(p.Job.Source.Commit) {
 		return fmt.Errorf("commit must be a SHA, or not provided")
 	}
 	return nil
@@ -137,7 +137,7 @@ func Run(params RunParams) error {
 }
 
 func generateOutput(params RunParams, api *server.API, outFile *os.File) ([]byte, error) {
-	if params.Job.Source.Commit == nil {
+	if params.Job.Source.Commit == "" {
 		// store the SHA we worked with for reproducible tests
 		params.Job.Source.Commit = api.Actual.Input.Job.Source.Commit
 	}

--- a/internal/infra/updater.go
+++ b/internal/infra/updater.go
@@ -109,11 +109,11 @@ func putUpdaterInputs(ctx context.Context, cli *client.Client, cert, id string, 
 		return fmt.Errorf("failed to copy cert to container: %w", err)
 	}
 
-	data, err := json.Marshal(FileFetcherJobFile{Job: job})
+	data, err := JobFile{Job: job}.ToJSON()
 	if err != nil {
 		return fmt.Errorf("failed to marshal job file: %w", err)
 	}
-	if t, err := tarball(guestInputDir, string(data)); err != nil {
+	if t, err := tarball(guestInputDir, data); err != nil {
 		return fmt.Errorf("failed create input tarball: %w", err)
 	} else if err = cli.CopyToContainer(ctx, id, "/", t, opt); err != nil {
 		return fmt.Errorf("failed to copy input to container: %w", err)
@@ -278,9 +278,14 @@ func (u *Updater) Close() error {
 	})
 }
 
-// FileFetcherJobFile  is the payload passed to file updater containers.
-type FileFetcherJobFile struct {
+// JobFile  is the payload passed to file updater containers.
+type JobFile struct {
 	Job *model.Job `json:"job"`
+}
+
+func (j JobFile) ToJSON() (string, error) {
+	data, err := json.Marshal(j)
+	return string(data), err
 }
 
 func tarball(name, contents string) (*bytes.Buffer, error) {

--- a/internal/infra/updater_test.go
+++ b/internal/infra/updater_test.go
@@ -1,8 +1,10 @@
 package infra
 
 import (
+	"github.com/dependabot/cli/internal/model"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -47,4 +49,23 @@ func Test_mountOptions(t *testing.T) {
 			t.Errorf("For input '%v' got '%v' '%v' '%v' '%v'", test.input, local, remote, readOnly, err)
 		}
 	}
+}
+
+func TestJobFile_ToJSON(t *testing.T) {
+	t.Run("empty commit doesn't pass in empty string", func(t *testing.T) {
+		job := JobFile{
+			Job: &model.Job{
+				Source: model.Source{
+					Commit: "",
+				},
+			},
+		}
+		json, err := job.ToJSON()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(json, `"commit"`) {
+			t.Errorf("expected JSON to not contain commit: %v", json)
+		}
+	})
 }

--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -57,7 +57,7 @@ type Source struct {
 	Repo      string  `json:"repo" yaml:"repo,omitempty"`
 	Directory string  `json:"directory" yaml:"directory,omitempty"`
 	Branch    *string `json:"branch" yaml:"branch,omitempty"`
-	Commit    *string `json:"commit" yaml:"commit,omitempty"`
+	Commit    string  `json:"commit,omitempty" yaml:"commit,omitempty"`
 
 	Hostname    *string `json:"hostname" yaml:"hostname,omitempty"`         // Must be provided if APIEndpoint is
 	APIEndpoint *string `json:"api-endpoint" yaml:"api-endpoint,omitempty"` // Must be provided if Hostname is

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -198,7 +198,7 @@ func (a *API) pushResult(kind string, actual *model.UpdateWrapper) error {
 
 	if msg, ok := actual.Data.(model.MarkAsProcessed); ok {
 		// record the commit SHA so the test is reproducible
-		a.Actual.Input.Job.Source.Commit = &msg.BaseCommitSha
+		a.Actual.Input.Job.Source.Commit = msg.BaseCommitSha
 	}
 
 	return nil


### PR DESCRIPTION
While debugging an issue I noticed that `dependabot update github_actions dependabot/smoke-tests` doesn't work. It tries to pull a blank ref which fails.

The cause of this is due to the `--commit` option defaulting to `""` which gets passed into the updater via `job.json`. This makes the updater think there's a commit present, but when it goes to use it, it's blank and the update fails. 

I swapped out the pointer on the type which simplifies a bunch of code, but adding the `omitempty` is what actually fixes the problem. 