### PR TITLE
Allow running OpenTelemetry collector

### DIFF
--- a/cmd/dependabot/internal/cmd/root.go
+++ b/cmd/dependabot/internal/cmd/root.go
@@ -15,7 +15,6 @@ var (
 	file                string
 	cache               string
 	debugging           bool
-	enableOpenTelemetry bool
 	proxyCertPath       string
 	collectorConfigPath string
 	extraHosts          []string

--- a/cmd/dependabot/internal/cmd/root.go
+++ b/cmd/dependabot/internal/cmd/root.go
@@ -12,17 +12,20 @@ import (
 )
 
 var (
-	file          string
-	cache         string
-	debugging     bool
-	proxyCertPath string
-	extraHosts    []string
-	output        string
-	pullImages    bool
-	volumes       []string
-	timeout       time.Duration
-	updaterImage  string
-	proxyImage    string
+	file                string
+	cache               string
+	debugging           bool
+	enableOpenTelemetry bool
+	proxyCertPath       string
+	collectorConfigPath string
+	extraHosts          []string
+	output              string
+	pullImages          bool
+	volumes             []string
+	timeout             time.Duration
+	updaterImage        string
+	proxyImage          string
+	collectorImage      string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -50,4 +53,5 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&updaterImage, "updater-image", "", "container image to use for the updater")
 	rootCmd.PersistentFlags().StringVar(&proxyImage, "proxy-image", infra.ProxyImageName, "container image to use for the proxy")
+	rootCmd.PersistentFlags().StringVar(&collectorImage, "collector-image", infra.CollectorImageName, "container image to use for the OpenTelemetry collector")
 }

--- a/cmd/dependabot/internal/cmd/test.go
+++ b/cmd/dependabot/internal/cmd/test.go
@@ -38,6 +38,8 @@ var testCmd = &cobra.Command{
 
 		if err := infra.Run(infra.RunParams{
 			CacheDir:            cache,
+			CollectorConfigPath: collectorConfigPath,
+			CollectorImage:      collectorImage,
 			Creds:               scenario.Input.Credentials,
 			Debug:               debugging,
 			EnableOpenTelemetry: enableOpenTelemetry,
@@ -50,8 +52,6 @@ var testCmd = &cobra.Command{
 			Output:              output,
 			ProxyCertPath:       proxyCertPath,
 			ProxyImage:          proxyImage,
-			CollectorConfigPath: collectorConfigPath,
-			CollectorImage:      collectorImage,
 			PullImages:          pullImages,
 			Timeout:             timeout,
 			UpdaterImage:        updaterImage,

--- a/cmd/dependabot/internal/cmd/test.go
+++ b/cmd/dependabot/internal/cmd/test.go
@@ -42,7 +42,6 @@ var testCmd = &cobra.Command{
 			CollectorImage:      collectorImage,
 			Creds:               scenario.Input.Credentials,
 			Debug:               debugging,
-			EnableOpenTelemetry: enableOpenTelemetry,
 			Expected:            scenario.Output,
 			ExtraHosts:          extraHosts,
 			InputName:           file,
@@ -94,7 +93,6 @@ func init() {
 	testCmd.Flags().StringVar(&collectorConfigPath, "collector-config", "", "path to an OpenTelemetry collector config file")
 	testCmd.Flags().BoolVar(&pullImages, "pull", true, "pull the image if it isn't present")
 	testCmd.Flags().BoolVar(&debugging, "debug", false, "run an interactive shell inside the updater")
-	testCmd.Flags().BoolVar(&enableOpenTelemetry, "enable-opentelemetry", false, "enable OpenTelemetry tracing")
 	testCmd.Flags().StringArrayVarP(&volumes, "volume", "v", nil, "mount volumes in Docker")
 	testCmd.Flags().StringArrayVar(&extraHosts, "extra-hosts", nil, "Docker extra hosts setting on the proxy")
 	testCmd.Flags().DurationVarP(&timeout, "timeout", "t", 0, "max time to run an update")

--- a/cmd/dependabot/internal/cmd/test.go
+++ b/cmd/dependabot/internal/cmd/test.go
@@ -37,22 +37,25 @@ var testCmd = &cobra.Command{
 		processInput(&scenario.Input)
 
 		if err := infra.Run(infra.RunParams{
-			CacheDir:      cache,
-			Creds:         scenario.Input.Credentials,
-			Debug:         debugging,
-			Expected:      scenario.Output,
-			ExtraHosts:    extraHosts,
-			InputName:     file,
-			InputRaw:      inputRaw,
-			Job:           &scenario.Input.Job,
-			LocalDir:      local,
-			Output:        output,
-			ProxyCertPath: proxyCertPath,
-			ProxyImage:    proxyImage,
-			PullImages:    pullImages,
-			Timeout:       timeout,
-			UpdaterImage:  updaterImage,
-			Volumes:       volumes,
+			CacheDir:            cache,
+			Creds:               scenario.Input.Credentials,
+			Debug:               debugging,
+			EnableOpenTelemetry: enableOpenTelemetry,
+			Expected:            scenario.Output,
+			ExtraHosts:          extraHosts,
+			InputName:           file,
+			InputRaw:            inputRaw,
+			Job:                 &scenario.Input.Job,
+			LocalDir:            local,
+			Output:              output,
+			ProxyCertPath:       proxyCertPath,
+			ProxyImage:          proxyImage,
+			CollectorConfigPath: collectorConfigPath,
+			CollectorImage:      collectorImage,
+			PullImages:          pullImages,
+			Timeout:             timeout,
+			UpdaterImage:        updaterImage,
+			Volumes:             volumes,
 		}); err != nil {
 			log.Fatal(err)
 		}
@@ -88,8 +91,10 @@ func init() {
 	testCmd.Flags().StringVar(&cache, "cache", "", "cache import/export directory")
 	testCmd.Flags().StringVar(&local, "local", "", "local directory to use as fetched source")
 	testCmd.Flags().StringVar(&proxyCertPath, "proxy-cert", "", "path to a certificate the proxy will trust")
+	testCmd.Flags().StringVar(&collectorConfigPath, "collector-config", "", "path to an OpenTelemetry collector config file")
 	testCmd.Flags().BoolVar(&pullImages, "pull", true, "pull the image if it isn't present")
 	testCmd.Flags().BoolVar(&debugging, "debug", false, "run an interactive shell inside the updater")
+	testCmd.Flags().BoolVar(&enableOpenTelemetry, "enable-opentelemetry", false, "enable OpenTelemetry tracing")
 	testCmd.Flags().StringArrayVarP(&volumes, "volume", "v", nil, "mount volumes in Docker")
 	testCmd.Flags().StringArrayVar(&extraHosts, "extra-hosts", nil, "Docker extra hosts setting on the proxy")
 	testCmd.Flags().DurationVarP(&timeout, "timeout", "t", 0, "max time to run an update")

--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -66,7 +66,6 @@ func NewUpdateCommand() *cobra.Command {
 				CollectorImage:      collectorImage,
 				Creds:               input.Credentials,
 				Debug:               debugging,
-				EnableOpenTelemetry: enableOpenTelemetry,
 				Expected:            nil, // update subcommand doesn't use expectations
 				ExtraHosts:          extraHosts,
 				InputName:           file,
@@ -102,7 +101,6 @@ func NewUpdateCommand() *cobra.Command {
 	cmd.Flags().StringVar(&collectorConfigPath, "collector-config", "", "path to an OpenTelemetry collector config file")
 	cmd.Flags().BoolVar(&pullImages, "pull", true, "pull the image if it isn't present")
 	cmd.Flags().BoolVar(&debugging, "debug", false, "run an interactive shell inside the updater")
-	cmd.Flags().BoolVar(&enableOpenTelemetry, "enable-opentelemetry", false, "enable OpenTelemetry tracing")
 	cmd.Flags().StringArrayVarP(&volumes, "volume", "v", nil, "mount volumes in Docker")
 	cmd.Flags().StringArrayVar(&extraHosts, "extra-hosts", nil, "Docker extra hosts setting on the proxy")
 	cmd.Flags().DurationVarP(&timeout, "timeout", "t", 0, "max time to run an update")

--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -62,6 +62,8 @@ func NewUpdateCommand() *cobra.Command {
 
 			if err := infra.Run(infra.RunParams{
 				CacheDir:            cache,
+				CollectorConfigPath: collectorConfigPath,
+				CollectorImage:      collectorImage,
 				Creds:               input.Credentials,
 				Debug:               debugging,
 				EnableOpenTelemetry: enableOpenTelemetry,
@@ -73,13 +75,11 @@ func NewUpdateCommand() *cobra.Command {
 				Output:              output,
 				ProxyCertPath:       proxyCertPath,
 				ProxyImage:          proxyImage,
-				CollectorConfigPath: collectorConfigPath,
-				CollectorImage:      collectorImage,
 				PullImages:          pullImages,
 				Timeout:             timeout,
 				UpdaterImage:        updaterImage,
-				Writer:              writer,
 				Volumes:             volumes,
+				Writer:              writer,
 			}); err != nil {
 				log.Fatalf("failed to run updater: %v", err)
 			}

--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -61,22 +61,25 @@ func NewUpdateCommand() *cobra.Command {
 			}
 
 			if err := infra.Run(infra.RunParams{
-				CacheDir:      cache,
-				Creds:         input.Credentials,
-				Debug:         debugging,
-				Expected:      nil, // update subcommand doesn't use expectations
-				ExtraHosts:    extraHosts,
-				InputName:     file,
-				Job:           &input.Job,
-				LocalDir:      local,
-				Output:        output,
-				ProxyCertPath: proxyCertPath,
-				ProxyImage:    proxyImage,
-				PullImages:    pullImages,
-				Timeout:       timeout,
-				UpdaterImage:  updaterImage,
-				Writer:        writer,
-				Volumes:       volumes,
+				CacheDir:            cache,
+				Creds:               input.Credentials,
+				Debug:               debugging,
+				EnableOpenTelemetry: enableOpenTelemetry,
+				Expected:            nil, // update subcommand doesn't use expectations
+				ExtraHosts:          extraHosts,
+				InputName:           file,
+				Job:                 &input.Job,
+				LocalDir:            local,
+				Output:              output,
+				ProxyCertPath:       proxyCertPath,
+				ProxyImage:          proxyImage,
+				CollectorConfigPath: collectorConfigPath,
+				CollectorImage:      collectorImage,
+				PullImages:          pullImages,
+				Timeout:             timeout,
+				UpdaterImage:        updaterImage,
+				Writer:              writer,
+				Volumes:             volumes,
 			}); err != nil {
 				log.Fatalf("failed to run updater: %v", err)
 			}
@@ -96,8 +99,10 @@ func NewUpdateCommand() *cobra.Command {
 	cmd.Flags().StringVar(&cache, "cache", "", "cache import/export directory")
 	cmd.Flags().StringVar(&local, "local", "", "local directory to use as fetched source")
 	cmd.Flags().StringVar(&proxyCertPath, "proxy-cert", "", "path to a certificate the proxy will trust")
+	cmd.Flags().StringVar(&collectorConfigPath, "collector-config", "", "path to an OpenTelemetry collector config file")
 	cmd.Flags().BoolVar(&pullImages, "pull", true, "pull the image if it isn't present")
 	cmd.Flags().BoolVar(&debugging, "debug", false, "run an interactive shell inside the updater")
+	cmd.Flags().BoolVar(&enableOpenTelemetry, "enable-opentelemetry", false, "enable OpenTelemetry tracing")
 	cmd.Flags().StringArrayVarP(&volumes, "volume", "v", nil, "mount volumes in Docker")
 	cmd.Flags().StringArrayVar(&extraHosts, "extra-hosts", nil, "Docker extra hosts setting on the proxy")
 	cmd.Flags().DurationVarP(&timeout, "timeout", "t", 0, "max time to run an update")

--- a/internal/infra/open_telemetry.go
+++ b/internal/infra/open_telemetry.go
@@ -91,9 +91,14 @@ func NewCollector(ctx context.Context, cli *client.Client, net *Networks, params
 
 }
 
-// Close kills and deletes the container and deletes updater mount paths related to the run.
-func (u *Collector) Close() error {
-	return u.cli.ContainerRemove(context.Background(), u.containerID, types.ContainerRemoveOptions{
-		Force: true,
-	})
+// Close stops and removes the container.
+func (c *Collector) Close() error {
+	timeout := 5
+	_ = c.cli.ContainerStop(context.Background(), c.containerID, container.StopOptions{Timeout: &timeout})
+
+	err := c.cli.ContainerRemove(context.Background(), c.containerID, types.ContainerRemoveOptions{Force: true})
+	if err != nil {
+		return fmt.Errorf("failed to remove collector container: %w", err)
+	}
+	return nil
 }

--- a/internal/infra/open_telemetry.go
+++ b/internal/infra/open_telemetry.go
@@ -1,0 +1,99 @@
+package infra
+
+import (
+	"context"
+	"fmt"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/api/types/network"
+	"github.com/moby/moby/client"
+	"os"
+	"path"
+	"path/filepath"
+)
+
+// CollectorImageName is the default Docker image used
+const CollectorImageName = "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest"
+
+const CollectorConfigPath = "/etc/otelcol-contrib/config.yaml"
+
+const sslCertificates = "/etc/ssl/certs/ca-certificates.crt"
+
+type Collector struct {
+	cli         *client.Client
+	containerID string
+}
+
+// NewCollector starts the OpenTelemetry collector container.
+func NewCollector(ctx context.Context, cli *client.Client, net *Networks, params *RunParams, proxy *Proxy) (*Collector, error) {
+	hostCfg := &container.HostConfig{
+		AutoRemove: false,
+	}
+
+	containerCfg := &container.Config{
+		Image: params.CollectorImage,
+		Env: []string{
+			fmt.Sprintf("HTTP_PROXY=%s", proxy.url),
+			fmt.Sprintf("HTTPS_PROXY=%s", proxy.url),
+		},
+	}
+
+	netCfg := &network.NetworkingConfig{
+		EndpointsConfig: map[string]*network.EndpointSettings{
+			net.noInternetName: {
+				NetworkID: net.NoInternet.ID,
+			},
+		},
+	}
+
+	if params.CollectorConfigPath != "" {
+		if !filepath.IsAbs(params.CollectorConfigPath) {
+			// needs to be absolute, assume it is relative to the working directory
+			var dir string
+			dir, err := os.Getwd()
+			if err != nil {
+				return nil, fmt.Errorf("couldn't get working directory: %w", err)
+			}
+			params.CollectorConfigPath = path.Join(dir, params.CollectorConfigPath)
+		}
+		hostCfg.Mounts = append(hostCfg.Mounts, mount.Mount{
+			Type:     mount.TypeBind,
+			Source:   params.CollectorConfigPath,
+			Target:   CollectorConfigPath,
+			ReadOnly: true,
+		})
+	}
+
+	collectorContainer, err := cli.ContainerCreate(ctx, containerCfg, hostCfg, netCfg, nil, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create collector container: %w", err)
+	}
+
+	collector := &Collector{
+		cli:         cli,
+		containerID: collectorContainer.ID,
+	}
+
+	opt := types.CopyToContainerOptions{}
+	if t, err := tarball(sslCertificates, proxy.ca.Cert); err != nil {
+		return nil, fmt.Errorf("failed to create cert tarball: %w", err)
+	} else if err = cli.CopyToContainer(ctx, collector.containerID, "/", t, opt); err != nil {
+		return nil, fmt.Errorf("failed to copy cert to container: %w", err)
+	}
+
+	if err = cli.ContainerStart(ctx, collectorContainer.ID, types.ContainerStartOptions{}); err != nil {
+		collector.Close()
+		return nil, fmt.Errorf("failed to start collector container: %w", err)
+	}
+
+	return collector, nil
+
+}
+
+// Close kills and deletes the container and deletes updater mount paths related to the run.
+func (u *Collector) Close() error {
+	return u.cli.ContainerRemove(context.Background(), u.containerID, types.ContainerRemoveOptions{
+		Force: true,
+	})
+}

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -46,8 +46,6 @@ type RunParams struct {
 	PullImages bool
 	// run an interactive shell?
 	Debug bool
-	// EnableOpenTelemetry enables OpenTelemetry tracing
-	EnableOpenTelemetry bool
 	// Volumes are used to mount directories in Docker
 	Volumes []string
 	// Timeout specifies an optional maximum duration the CLI will run an update.
@@ -335,7 +333,7 @@ func runContainers(ctx context.Context, params RunParams, api *server.API) error
 			return err
 		}
 
-		if params.EnableOpenTelemetry == true {
+		if params.CollectorConfigPath != "" {
 			err = pullImage(ctx, cli, params.CollectorImage)
 			if err != nil {
 				return err
@@ -365,7 +363,7 @@ func runContainers(ctx context.Context, params RunParams, api *server.API) error
 		go prox.TailLogs(ctx, cli)
 	}
 
-	if params.EnableOpenTelemetry {
+	if params.CollectorConfigPath != "" {
 		collector, err := NewCollector(ctx, cli, networks, &params, prox)
 		if err != nil {
 			return err

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -335,9 +335,11 @@ func runContainers(ctx context.Context, params RunParams, api *server.API) error
 			return err
 		}
 
-		err = pullImage(ctx, cli, params.CollectorImage)
-		if err != nil {
-			return err
+		if params.EnableOpenTelemetry == true {
+			err = pullImage(ctx, cli, params.CollectorImage)
+			if err != nil {
+				return err
+			}
 		}
 
 		err = pullImage(ctx, cli, params.UpdaterImage)

--- a/internal/infra/updater.go
+++ b/internal/infra/updater.go
@@ -54,7 +54,7 @@ func NewUpdater(ctx context.Context, cli *client.Client, net *Networks, params *
 		Tty:   true, // prevent container from stopping
 	}
 
-	if params.EnableOpenTelemetry == true {
+	if params.CollectorConfigPath != "" {
 		containerCfg.Env = append(containerCfg.Env, "OTEL_ENABLED=true")
 	}
 

--- a/internal/infra/updater.go
+++ b/internal/infra/updater.go
@@ -53,6 +53,11 @@ func NewUpdater(ctx context.Context, cli *client.Client, net *Networks, params *
 		Cmd:   []string{"/bin/sh"},
 		Tty:   true, // prevent container from stopping
 	}
+
+	if params.EnableOpenTelemetry == true {
+		containerCfg.Env = append(containerCfg.Env, "OTEL_ENABLED=true")
+	}
+
 	hostCfg := &container.HostConfig{}
 	var err error
 	for _, v := range params.Volumes {


### PR DESCRIPTION
This PR adds the ability to run an [OpenTelemetryCollector][1] container image alongside the proxy and updater image. This depends on dependabot/dependabot-core#8210, which adds the OpenTelemetry SDK to `dependabot-core`.

The main changes in this PR are:
- The OpenTelemetry collector is run after the proxy container, but before the updater container
- 3 new CLI flags:
  - `enable-opentelemetry` a boolean flag to control if the OpenTelemetry collector container should be created, and the `OTEL_ENABLED` environment variable should be passed to the updater container
  - `collector-image` a string flag that controls which container image to use for the OpenTelemetry collector. Defaults to `ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest`. See [the Dockerfile for this container image here][3]
  - `collector-config` a string flag that sets a path to [OpenTelemetry collector YAML configuration][2]. I've been using the following for testing:
    
    <details>
    <summary>Click to expand</summary>
    
    ```yaml
    receivers:
	  otlp:
	    protocols:
	      grpc:
	
	exporters:
	  debug:
	
	processors:
	  batch:
	
	service:
	  pipelines:
	    traces:
	      receivers: [otlp]
	      processors: [batch]
	      exporters: [debug]
	    metrics:
	      receivers: [otlp]
	      processors: [batch]
	      exporters: [debug]
    ```
    </details>


[1]: https://opentelemetry.io/docs/collector/
[2]: https://opentelemetry.io/docs/collector/configuration/
[3]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/cmd/otelcontribcol/Dockerfile