### PR TITLE
Set otel export url

### DIFF
--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -363,15 +363,16 @@ func runContainers(ctx context.Context, params RunParams, api *server.API) error
 		go prox.TailLogs(ctx, cli)
 	}
 
+	var collector *Collector
 	if params.CollectorConfigPath != "" {
-		collector, err := NewCollector(ctx, cli, networks, &params, prox)
+		collector, err = NewCollector(ctx, cli, networks, &params, prox)
 		if err != nil {
 			return err
 		}
 		defer collector.Close()
 	}
 
-	updater, err := NewUpdater(ctx, cli, networks, &params, prox)
+	updater, err := NewUpdater(ctx, cli, networks, &params, prox, collector)
 	if err != nil {
 		return err
 	}

--- a/internal/infra/updater.go
+++ b/internal/infra/updater.go
@@ -46,7 +46,7 @@ const (
 )
 
 // NewUpdater starts the update container interactively running /bin/sh, so it does not stop.
-func NewUpdater(ctx context.Context, cli *client.Client, net *Networks, params *RunParams, prox *Proxy) (*Updater, error) {
+func NewUpdater(ctx context.Context, cli *client.Client, net *Networks, params *RunParams, prox *Proxy, collector *Collector) (*Updater, error) {
 	containerCfg := &container.Config{
 		User:  dependabot,
 		Image: params.UpdaterImage,
@@ -55,7 +55,12 @@ func NewUpdater(ctx context.Context, cli *client.Client, net *Networks, params *
 	}
 
 	if params.CollectorConfigPath != "" {
-		containerCfg.Env = append(containerCfg.Env, "OTEL_ENABLED=true")
+		containerCfg.Env = append(
+			containerCfg.Env,
+			[]string{
+				"OTEL_ENABLED=true",
+				fmt.Sprintf("OTEL_EXPORTER_OTLP_ENDPOINT=%s", collector.url),
+			}...)
 	}
 
 	hostCfg := &container.HostConfig{}


### PR DESCRIPTION
The default value of `OTEL_EXPORTER_OTLP_ENDPOINT` is `localhost:4318`[^1]. This change is necessary for the updater container to post telemetry to the collector OTLP endpoint on the docker network. Typically this is something in the `172.16.0.0/12` block.

[^1]: https://opentelemetry.io/docs/specs/otel/protocol/exporter/#configuration-options