### PR TITLE
fix flaky test

### DIFF
--- a/internal/server/input_test.go
+++ b/internal/server/input_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/dependabot/cli/internal/model"
 )
@@ -17,6 +18,8 @@ func TestInput(t *testing.T) {
 		input, _ = Input(8080)
 		wg.Done()
 	}()
+	// give the server time to start
+	time.Sleep(10 * time.Millisecond)
 
 	data := `{"job":{"package-manager":"test"},"credentials":[{"credential":"value"}]}`
 	resp, err := http.Post("http://localhost:8080", "application/json", bytes.NewReader([]byte(data)))


### PR DESCRIPTION
This test tends to fail because the server hasn't had a chance to start. Most likely the goroutine hasn't even run. Putting in a short sleep is the easy way to fix it. Other solutions would require refactor to allow for starting a listener and then passing it into Input. I'm good with the sleep 😄 