### PR TITLE
refactor test command to add a test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ tmp
 testdata/caches
 cache
 out.yaml
-dependabot
+./dependabot

--- a/cmd/dependabot/internal/cmd/root.go
+++ b/cmd/dependabot/internal/cmd/root.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
+type SharedFlags struct {
 	file                string
 	cache               string
 	debugging           bool
@@ -22,9 +22,14 @@ var (
 	pullImages          bool
 	volumes             []string
 	timeout             time.Duration
-	updaterImage        string
-	proxyImage          string
-	collectorImage      string
+	local               string
+}
+
+// root flags
+var (
+	updaterImage   string
+	proxyImage     string
+	collectorImage string
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/cmd/dependabot/internal/cmd/test.go
+++ b/cmd/dependabot/internal/cmd/test.go
@@ -13,55 +13,71 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var (
-	jobs int
-)
+// local variable for testing
+var executeTestJob = infra.Run
 
-var testCmd = &cobra.Command{
-	Use:   "test -f <scenario.yml>",
-	Short: "Test scenarios",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if jobs < 1 {
-			return fmt.Errorf("workers must be greater than or equal to 1")
-		}
+func NewTestCommand() *cobra.Command {
+	var flags SharedFlags
 
-		if file == "" {
-			return fmt.Errorf("requires a scenario file")
-		}
+	cmd := &cobra.Command{
+		Use:   "test -f <scenario.yml>",
+		Short: "Test scenarios",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if flags.file == "" {
+				return fmt.Errorf("requires a scenario file")
+			}
 
-		scenario, inputRaw, err := readScenarioFile(file)
-		if err != nil {
-			return err
-		}
+			scenario, inputRaw, err := readScenarioFile(flags.file)
+			if err != nil {
+				return err
+			}
 
-		processInput(&scenario.Input)
+			processInput(&scenario.Input)
 
-		if err := infra.Run(infra.RunParams{
-			CacheDir:            cache,
-			CollectorConfigPath: collectorConfigPath,
-			CollectorImage:      collectorImage,
-			Creds:               scenario.Input.Credentials,
-			Debug:               debugging,
-			Expected:            scenario.Output,
-			ExtraHosts:          extraHosts,
-			InputName:           file,
-			InputRaw:            inputRaw,
-			Job:                 &scenario.Input.Job,
-			LocalDir:            local,
-			Output:              output,
-			ProxyCertPath:       proxyCertPath,
-			ProxyImage:          proxyImage,
-			PullImages:          pullImages,
-			Timeout:             timeout,
-			UpdaterImage:        updaterImage,
-			Volumes:             volumes,
-		}); err != nil {
-			log.Fatal(err)
-		}
+			if err := executeTestJob(infra.RunParams{
+				CacheDir:            flags.cache,
+				CollectorConfigPath: flags.collectorConfigPath,
+				CollectorImage:      collectorImage,
+				Creds:               scenario.Input.Credentials,
+				Debug:               flags.debugging,
+				Expected:            scenario.Output,
+				ExtraHosts:          flags.extraHosts,
+				InputName:           flags.file,
+				InputRaw:            inputRaw,
+				Job:                 &scenario.Input.Job,
+				LocalDir:            flags.local,
+				Output:              flags.output,
+				ProxyCertPath:       flags.proxyCertPath,
+				ProxyImage:          proxyImage,
+				PullImages:          flags.pullImages,
+				Timeout:             flags.timeout,
+				UpdaterImage:        updaterImage,
+				Volumes:             flags.volumes,
+			}); err != nil {
+				log.Fatal(err)
+			}
 
-		return nil
-	},
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&flags.file, "file", "f", "", "path to scenario file")
+
+	cmd.Flags().StringVarP(&flags.output, "output", "o", "", "write scenario to file")
+	cmd.Flags().StringVar(&flags.cache, "cache", "", "cache import/export directory")
+	cmd.Flags().StringVar(&flags.local, "local", "", "local directory to use as fetched source")
+	cmd.Flags().StringVar(&flags.proxyCertPath, "proxy-cert", "", "path to a certificate the proxy will trust")
+	cmd.Flags().StringVar(&flags.collectorConfigPath, "collector-config", "", "path to an OpenTelemetry collector config file")
+	cmd.Flags().BoolVar(&flags.pullImages, "pull", true, "pull the image if it isn't present")
+	cmd.Flags().BoolVar(&flags.debugging, "debug", false, "run an interactive shell inside the updater")
+	cmd.Flags().StringArrayVarP(&flags.volumes, "volume", "v", nil, "mount volumes in Docker")
+	cmd.Flags().StringArrayVar(&flags.extraHosts, "extra-hosts", nil, "Docker extra hosts setting on the proxy")
+	cmd.Flags().DurationVarP(&flags.timeout, "timeout", "t", 0, "max time to run an update")
+
+	return cmd
 }
+
+var testCmd = NewTestCommand()
 
 func readScenarioFile(file string) (*model.Scenario, []byte, error) {
 	var scenario model.Scenario
@@ -81,19 +97,4 @@ func readScenarioFile(file string) (*model.Scenario, []byte, error) {
 
 func init() {
 	rootCmd.AddCommand(testCmd)
-
-	testCmd.Flags().StringVarP(&file, "file", "f", "", "path to scenario file")
-	testCmd.Flags().IntVarP(&jobs, "jobs", "j", 1, "Number of jobs to run simultaneously")
-	testCmd.MarkFlagsMutuallyExclusive("jobs", "file")
-
-	testCmd.Flags().StringVarP(&output, "output", "o", "", "write scenario to file")
-	testCmd.Flags().StringVar(&cache, "cache", "", "cache import/export directory")
-	testCmd.Flags().StringVar(&local, "local", "", "local directory to use as fetched source")
-	testCmd.Flags().StringVar(&proxyCertPath, "proxy-cert", "", "path to a certificate the proxy will trust")
-	testCmd.Flags().StringVar(&collectorConfigPath, "collector-config", "", "path to an OpenTelemetry collector config file")
-	testCmd.Flags().BoolVar(&pullImages, "pull", true, "pull the image if it isn't present")
-	testCmd.Flags().BoolVar(&debugging, "debug", false, "run an interactive shell inside the updater")
-	testCmd.Flags().StringArrayVarP(&volumes, "volume", "v", nil, "mount volumes in Docker")
-	testCmd.Flags().StringArrayVar(&extraHosts, "extra-hosts", nil, "Docker extra hosts setting on the proxy")
-	testCmd.Flags().DurationVarP(&timeout, "timeout", "t", 0, "max time to run an update")
 }

--- a/cmd/dependabot/internal/cmd/test_test.go
+++ b/cmd/dependabot/internal/cmd/test_test.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"github.com/dependabot/cli/internal/infra"
+	"testing"
+)
+
+func TestTestCommand(t *testing.T) {
+	t.Cleanup(func() {
+		executeTestJob = infra.Run
+	})
+
+	t.Run("Read a scenario file", func(t *testing.T) {
+		var actualParams *infra.RunParams
+		executeTestJob = func(params infra.RunParams) error {
+			actualParams = &params
+			return nil
+		}
+		cmd := NewTestCommand()
+		err := cmd.ParseFlags([]string{"-f", "../../../../testdata/scenario.yml"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		err = cmd.RunE(cmd, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if actualParams == nil {
+			t.Fatalf("expected params to be set")
+		}
+		if actualParams.InputName == "" {
+			t.Errorf("expected input name to be set")
+		}
+		if actualParams.Job.PackageManager != "go_modules" {
+			t.Errorf("expected package manager to be set")
+		}
+	})
+}

--- a/cmd/dependabot/internal/cmd/update_test.go
+++ b/cmd/dependabot/internal/cmd/update_test.go
@@ -95,7 +95,7 @@ func Test_extractInput(t *testing.T) {
 		if err := cmd.ParseFlags([]string{"go_modules", "rsc/quote"}); err != nil {
 			t.Fatal(err)
 		}
-		input, err := extractInput(cmd)
+		input, err := extractInput(cmd, &UpdateFlags{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -105,11 +105,12 @@ func Test_extractInput(t *testing.T) {
 	})
 	t.Run("test file", func(t *testing.T) {
 		cmd := NewUpdateCommand()
-		// The working directory is cmd/dependabot/internal/cmd
-		if err := cmd.ParseFlags([]string{"-f", "../../../../testdata/basic.yml"}); err != nil {
-			t.Fatal(err)
-		}
-		input, err := extractInput(cmd)
+		input, err := extractInput(cmd, &UpdateFlags{
+			SharedFlags: SharedFlags{
+				// The working directory is cmd/dependabot/internal/cmd
+				file: "../../../../testdata/basic.yml",
+			},
+		})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -132,10 +133,9 @@ func Test_extractInput(t *testing.T) {
 		}()
 
 		cmd := NewUpdateCommand()
-		if err := cmd.ParseFlags([]string{"--input-port", "8080"}); err != nil {
-			t.Fatal(err)
-		}
-		input, err := extractInput(cmd)
+		input, err := extractInput(cmd, &UpdateFlags{
+			inputServerPort: 8080,
+		})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -165,7 +165,7 @@ func Test_extractInput(t *testing.T) {
 		}
 
 		cmd := NewUpdateCommand()
-		input, err := extractInput(cmd)
+		input, err := extractInput(cmd, &UpdateFlags{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -178,7 +178,7 @@ func Test_extractInput(t *testing.T) {
 		if err := cmd.ParseFlags([]string{"go_modules", "-f", "basic.yml"}); err != nil {
 			t.Fatal(err)
 		}
-		_, err := extractInput(cmd)
+		_, err := extractInput(cmd, &UpdateFlags{})
 		if err == nil {
 			t.Errorf("expected error, got nil")
 		}

--- a/testdata/scenario.yml
+++ b/testdata/scenario.yml
@@ -1,0 +1,10 @@
+input:
+  job:
+    package-manager: go_modules
+    allowed-updates:
+      - dependency-type: direct
+        update-type: all
+    source:
+      provider: github
+      repo: rsc/quote
+      directory: /


### PR DESCRIPTION
Refactored the flags into a struct and added a NewTestCommand to allow for testing of the RunE command. 

Initially we followed the Cobra pattern of using a package-level var block to initialize flags, but that led to functions operating on variables that weren't parameters to the function. Now by passing a flag struct around we can write more tests without worrying about "global" state.

Also the amount of flags has slowly grown, so having them all together in a struct is handy. In a future refactor we might push those flags down into the infra package to avoid having to copy them over into the nebulous infra.Params. 