### PR TITLE
chore(docs): fix hyperlink for job description examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ with values from the environment.
 > **Note**
 >
 > The job description file format isn't documented publicly,
-> but you can find examples in the [`testdata` directory](testdata/)
+> but you can find examples in the [`testdata` directory](cli/tree/main/testdata/)
 > and check out [the `Job` class in `dependabot-core`][dependabot-updater-job].
 
 ### How it works


### PR DESCRIPTION
Currently, the `README.md` takes you to a non existent page for examples of job descriptions:
https://github.com/dependabot/testdata/

This should now take you the right location:
https://github.com/dependabot/cli/tree/main/testdata