### PR TITLE
Fix errors with new record_unknown_job_error endpoint

### DIFF
--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -60,6 +60,11 @@ type RecordUpdateJobError struct {
 	ErrorDetails map[string]any `json:"error-details" yaml:"error-details"`
 }
 
+type RecordUpdateJobUnknownError struct {
+	ErrorType    string         `json:"error-type" yaml:"error-type"`
+	ErrorDetails map[string]any `json:"error-details" yaml:"error-details"`
+}
+
 type IncrementMetric struct {
 	Metric string         `json:"metric" yaml:"metric"`
 	Tags   map[string]any `json:"tags" yaml:"tags"`

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -233,6 +233,8 @@ func decodeWrapper(kind string, data []byte) (actual *model.UpdateWrapper, err e
 		actual.Data, err = decode[model.RecordEcosystemVersions](data)
 	case "record_update_job_error":
 		actual.Data, err = decode[model.RecordUpdateJobError](data)
+	case "record_update_job_unknown_error":
+		actual.Data, err = decode[model.RecordUpdateJobUnknownError](data)
 	case "increment_metric":
 		actual.Data, err = decode[model.IncrementMetric](data)
 	default:
@@ -285,6 +287,8 @@ func compare(expect, actual *model.UpdateWrapper) error {
 		return compareMarkAsProcessed(v, actual.Data.(model.MarkAsProcessed))
 	case model.RecordUpdateJobError:
 		return compareRecordUpdateJobError(v, actual.Data.(model.RecordUpdateJobError))
+	case model.RecordUpdateJobUnknownError:
+		return compareRecordUpdateJobUnknownError(v, actual.Data.(model.RecordUpdateJobUnknownError))
 	default:
 		return fmt.Errorf("unexpected type: %s", reflect.TypeOf(v))
 	}
@@ -341,4 +345,11 @@ func compareRecordUpdateJobError(expect, actual model.RecordUpdateJobError) erro
 		return nil
 	}
 	return unexpectedBody("record_update_job_error")
+}
+
+func compareRecordUpdateJobUnknownError(expect, actual model.RecordUpdateJobUnknownError) error {
+	if reflect.DeepEqual(expect, actual) {
+		return nil
+	}
+	return unexpectedBody("record_update_job_unknown_error")
 }


### PR DESCRIPTION
I'm getting the following errors when running the CLI:

```
(... omitted ...)

  proxy | 2023/11/16 11:16:11 [012] POST http://host.docker.internal:49797/update_jobs/cli/record_update_job_unknown_error
    cli | 2023/11/16 11:16:11 unexpected output type: record_update_job_unknown_error
  proxy | 2023/11/16 11:16:11 [012] 501 http://host.docker.internal:49797/update_jobs/cli/record_update_job_unknown_error
updater | 2023/11/16 11:16:11 ERROR 
updater | 2023/11/16 11:16:11 ERROR /home/dependabot/dependabot-updater/lib/dependabot/api_client.rb:116:in `record_update_job_unknown_error'
updater | 2023/11/16 11:16:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.1.0/gems/sorbet-runtime-0.5.11094/lib/types/private/methods/call_validation.rb:256:in `bind_call'
updater | 2023/11/16 11:16:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.1.0/gems/sorbet-runtime-0.5.11094/lib/types/private/methods/call_validation.rb:256:in `validate_call'
updater | 2023/11/16 11:16:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.1.0/gems/sorbet-runtime-0.5.11094/lib/types/private/methods/_methods.rb:275:in `block in _on_method_added'
updater | 2023/11/16 11:16:11 ERROR /home/dependabot/dependabot-updater/lib/dependabot/service.rb:68:in `record_update_job_unknown_error'
updater | 2023/11/16 11:16:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.1.0/gems/sorbet-runtime-0.5.11094/lib/types/private/methods/call_validation.rb:256:in `bind_call'
updater | 2023/11/16 11:16:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.1.0/gems/sorbet-runtime-0.5.11094/lib/types/private/methods/call_validation.rb:256:in `validate_call'
updater | 2023/11/16 11:16:11 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.1.0/gems/sorbet-runtime-0.5.11094/lib/types/private/methods/_methods.rb:275:in `block in _on_method_added'
updater | 2023/11/16 11:16:11 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/error_handler.rb:233:in `log_unknown_error_with_backtrace'
updater | 2023/11/16 11:16:11 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/error_handler.rb:55:in `handle_dependency_error'
updater | 2023/11/16 11:16:11 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/update_all_versions.rb:69:in `rescue in check_and_create_pr_with_error_handling'
updater | 2023/11/16 11:16:11 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/update_all_versions.rb:59:in `check_and_create_pr_with_error_handling'
updater | 2023/11/16 11:16:11 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/update_all_versions.rb:35:in `block in perform'
updater | 2023/11/16 11:16:11 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/update_all_versions.rb:35:in `each'
updater | 2023/11/16 11:16:11 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/update_all_versions.rb:35:in `perform'
updater | 2023/11/16 11:16:11 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:64:in `run'
updater | 2023/11/16 11:16:11 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:39:in `perform_job'
updater | 2023/11/16 11:16:11 ERROR /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:53:in `run'
updater | 2023/11/16 11:16:11 ERROR bin/update_files.rb:24:in `<main>'
  proxy | 2023/11/16 11:16:11 [013] POST http://host.docker.internal:49797/update_jobs/cli/record_update_job_error
{"data":{"error-type":"unknown_error","error-details":{"message":""}},"type":"record_update_job_error"}
  proxy | 2023/11/16 11:16:11 [013] 200 http://host.docker.internal:49797/update_jobs/cli/record_update_job_error
  proxy | 2023/11/16 11:16:11 [014] POST http://host.docker.internal:49797/update_jobs/cli/record_update_job_unknown_error
    cli | 2023/11/16 11:16:11 unexpected output type: record_update_job_unknown_error
  proxy | 2023/11/16 11:16:11 [014] 501 http://host.docker.internal:49797/update_jobs/cli/record_update_job_unknown_error

(... omitted ...)
```

These changes seem to fix it.