### PR TITLE
fix flaky server input test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Test
         # -count=2 ensures that test fixtures cleanup after themselves
         # because any leftover state will generally cause the second run to fail.
-        run: go test -shuffle=on -count=2 -race -cover -v ./...
+        run: go test -shuffle=on -count=2 -race -cover -v -timeout=5m ./...
 
   lint:
     runs-on: ubuntu-latest

--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"os"
 
 	"github.com/MakeNowJust/heredoc"
@@ -140,7 +141,11 @@ func extractInput(cmd *cobra.Command, flags *UpdateFlags) (*model.Input, error) 
 	}
 
 	if hasServer {
-		return server.Input(flags.inputServerPort)
+		l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", flags.inputServerPort))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create listener: %w", err)
+		}
+		return server.Input(l)
 	}
 
 	if hasStdin {


### PR DESCRIPTION
The fix is to start a listener outside of a goroutine that way the server is already listening and there's no need to wait or retry connections. 