### PR TITLE
Add .gitattributes file with text=auto eol=lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
This pull request includes a change to the `.gitattributes` file to enforce consistent line endings across different operating systems. The most significant change is the addition of a rule to ensure text files use the LF (Line Feed) line ending, which is standard on Unix-based systems like Linux and macOS.

Line endings consistency:

* <a href="diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eR1">`.gitattributes`</a>: Added a rule to enforce LF (Line Feed) line endings for all text files, ensuring consistency across different operating systems.configuration