### PR TITLE
Add cross-platform path support for proxy certificates

### DIFF
--- a/internal/infra/proxy.go
+++ b/internal/infra/proxy.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 )
 
 const proxyCertPath = "/usr/local/share/ca-certificates/custom-ca-cert.crt"
@@ -53,7 +52,7 @@ func NewProxy(ctx context.Context, cli *client.Client, params *RunParams, nets *
 	}
 	hostCfg.ExtraHosts = append(hostCfg.ExtraHosts, params.ExtraHosts...)
 	if params.ProxyCertPath != "" {
-		if !strings.HasPrefix(params.ProxyCertPath, "/") {
+		if !path.IsAbs(params.ProxyCertPath) {
 			// needs to be absolute, assume it is relative to the working directory
 			var dir string
 			dir, err = os.Getwd()


### PR DESCRIPTION
This pull request to `internal/infra/proxy.go` includes changes to simplify the codebase and improve the handling of file paths. The most important changes include removing the `strings` package from the import block and replacing the usage of `strings.HasPrefix` with `path.IsAbs` to check if a file path is absolute.

Codebase simplification:

* <a href="diffhunk://#diff-5788da3e7c1a0acab22a70cae6b739a8c50b0add7b20d019a4dec6eddf6adb45L20">`internal/infra/proxy.go`</a>: Removed the `strings` package from the import block as it is no longer needed.

Improvements in file path handling:

* <a href="diffhunk://#diff-5788da3e7c1a0acab22a70cae6b739a8c50b0add7b20d019a4dec6eddf6adb45L56-R55">`internal/infra/proxy.go`</a>: In the `NewProxy` function, replaced the usage of `strings.HasPrefix` with `path.IsAbs` to check if `params.ProxyCertPath` is an absolute path. This approach is more reliable and idiomatic for checking absolute paths in Go.