### PR TITLE
fix python-index not added to credentials-metadata

### DIFF
--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -363,20 +363,12 @@ func processInput(input *model.Input, flags *UpdateFlags) {
 	if len(input.Job.CredentialsMetadata) == 0 {
 		log.Println("Adding missing credentials-metadata into job definition")
 		for _, credential := range input.Credentials {
-			entry := map[string]any{
-				"type": credential["type"],
-			}
-			if credential["host"] != nil {
-				entry["host"] = credential["host"]
-			}
-			if credential["url"] != nil {
-				entry["url"] = credential["url"]
-			}
-			if credential["registry"] != nil {
-				entry["registry"] = credential["registry"]
-			}
-			if credential["replaces-base"] != nil {
-				entry["replaces-base"] = credential["replaces-base"]
+			entry := make(map[string]any)
+			for k, v := range credential {
+				// Updater does not get credentials.
+				if k != "token" && k != "password" {
+					entry[k] = v
+				}
 			}
 			input.Job.CredentialsMetadata = append(input.Job.CredentialsMetadata, entry)
 		}

--- a/cmd/dependabot/internal/cmd/update_test.go
+++ b/cmd/dependabot/internal/cmd/update_test.go
@@ -67,6 +67,7 @@ func Test_processInput(t *testing.T) {
 				"host":          "example.com",
 				"registry":      "registry.example.com",
 				"url":           "https://example.com",
+				"python-index":  "https://example.com",
 				"replaces-base": "true",
 				"password":      "password",
 			},
@@ -77,13 +78,14 @@ func Test_processInput(t *testing.T) {
 		if len(input.Job.CredentialsMetadata) != 1 {
 			t.Fatal("expected credentials metadata to be added")
 		}
-		if !reflect.DeepEqual(input.Job.CredentialsMetadata[0], model.Credential{
+		if !reflect.DeepEqual(input.Job.CredentialsMetadata, []model.Credential{{
 			"type":          "git_source",
 			"host":          "example.com",
 			"registry":      "registry.example.com",
 			"url":           "https://example.com",
+			"python-index":  "https://example.com",
 			"replaces-base": "true",
-		}) {
+		}}) {
 			t.Error("expected credentials metadata to be added")
 		}
 	})


### PR DESCRIPTION
fix #196

When using a job definition containing credentials for a python index, the Dependabot CLI was not correctly updating the credentials metadata which is passed to the Updater. 

To fix this I flipped the logic to exclude `token` and `password` during the metadata population routine, which should also fix any others that we might have missed or any that are added in the future.