### PR TITLE
hide more credentials from the updater

### DIFF
--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -366,7 +366,7 @@ func processInput(input *model.Input, flags *UpdateFlags) {
 			entry := make(map[string]any)
 			for k, v := range credential {
 				// Updater does not get credentials.
-				if k != "token" && k != "password" {
+				if k != "token" && k != "password" && k != "key" && k != "auth-key" {
 					entry[k] = v
 				}
 			}

--- a/cmd/dependabot/internal/cmd/update_test.go
+++ b/cmd/dependabot/internal/cmd/update_test.go
@@ -69,7 +69,12 @@ func Test_processInput(t *testing.T) {
 				"url":           "https://example.com",
 				"python-index":  "https://example.com",
 				"replaces-base": "true",
-				"password":      "password",
+
+				// These values will not propagate to the metadata
+				"password": "password",
+				"token":    "token",
+				"key":      "key",
+				"auth-key": "auth-key",
 			},
 		}
 


### PR DESCRIPTION
Following #215, this prevents key and auth-key fields from getting into the updater when generating credentials-metadata.

Thanks for spotting this @mctofu.