### PR TITLE
Update expected Azure repository format

### DIFF
--- a/internal/model/azure.go
+++ b/internal/model/azure.go
@@ -11,13 +11,13 @@ type AzureRepo struct {
 }
 
 // NewAzureRepo parses a repo string and returns an AzureRepo struct
-// Expects a repo string in the format org/project/repo
+// Expects a repo string in the format org/project/_git/repo
 func NewAzureRepo(packageManager string, repo string, directory string) *AzureRepo {
 	repoParts := strings.Split(repo, "/")
 	for i, part := range repoParts {
 		println(i, part)
 	}
-	if len(repoParts) != 3 {
+	if len(repoParts) != 4 {
 		return nil
 	}
 
@@ -25,7 +25,7 @@ func NewAzureRepo(packageManager string, repo string, directory string) *AzureRe
 		PackageManger: packageManager,
 		Org:           repoParts[0],
 		Project:       repoParts[1],
-		Repo:          repoParts[2],
+		Repo:          repoParts[3],
 		Directory:     directory,
 	}
 }

--- a/internal/model/azure_test.go
+++ b/internal/model/azure_test.go
@@ -16,7 +16,7 @@ func Test_NewAzureRepo(t *testing.T) {
 		{
 			name:           "valid repo",
 			packageManager: "npm_and_yarn",
-			repo:           "my-org/my-project/my-repo",
+			repo:           "my-org/my-project/_git/my-repo",
 			directory:      "/",
 			expected: &AzureRepo{
 				PackageManger: "npm_and_yarn",


### PR DESCRIPTION
Currently, dependabot-core uses the repository directly to construct the service pack URL:

https://github.com/dependabot/dependabot-core/blob/f6382ed6357c6c0020fb9083af7614400d5e3b65/common/lib/dependabot/git_metadata_fetcher.rb#L199-L204

This is fine for all other sources, except for Azure DevOps, where it constructs an invalid URL.

Before: `https://dev.azure.com:443/org/project/repo/info/refs?service=git-upload-pack` (404)
After `https://dev.azure.com:443/org/project/_git/repo/info/refs?service=git-upload-pack` (200)

A more long term fix would be to change how the URL is constructed in dependabot-core. But that is a larger and riskier change.