### PR TITLE
fix docs for job description examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ with values from the environment.
 > **Note**
 >
 > The job description file format isn't documented publicly,
-> but you can find examples in the [`testdata` directory](cli/tree/main/testdata/)
+> but you can find examples in the [`testdata` directory](testdata/)
 > and check out [the `Job` class in `dependabot-core`][dependabot-updater-job].
 
 ### How it works


### PR DESCRIPTION
# Description

It appears that the job description examples folder reference was wrongfully changed in #195 as if we navigate through the README and click the link, it opens https://github.com/dependabot/cli/blob/main/cli/tree/main/testdata which results in a not found page.

Specifying just `testdata/` should be enough to have the correct link to the `testdata` folder as github works nicely with relative links in markdown files: https://github.blog/2013-01-31-relative-links-in-markup-files/.