### PR TITLE
Fix gitignore to properly ignore a root dependabot binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@ tmp
 testdata/caches
 cache
 out.yaml
-./dependabot
+/dependabot
 dependabot.exe
 .env


### PR DESCRIPTION
This was changed in 90d144b8b1168aa477cba552cbaa5183393f8151, I think probably to restrict the gitignore to the file in root, but track any other potential folders or files named "dependabot". This makes sense but I think the rule was incorrect, it needs to start with `/`.