### PR TITLE
Add devcontainers to package manager mapping

### DIFF
--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -260,6 +260,7 @@ var packageManagerLookup = map[string]string{
 	"pip":            "pip",
 	"terraform":      "terraform",
 	"swift":          "swift",
+	"devcontainers":  "devcontainers",
 }
 
 func setImageNames(params *RunParams) error {


### PR DESCRIPTION
So that the CLI is able to pull the devcontainers image once it's there.

Part of https://github.com/github/dependabot-updates/issues/3334.