### PR TITLE
remove credentials-metadata from input

### DIFF
--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -362,21 +362,16 @@ func processInput(input *model.Input, flags *UpdateFlags) {
 		}
 	}
 
-	// As a convenience, fill credentials-metadata if credentials are provided
-	// which is what happens in production. This way the user doesn't have to
-	// specify credentials-metadata in the scenario file unless they want to.
-	if len(input.Job.CredentialsMetadata) == 0 {
-		log.Println("Adding missing credentials-metadata into job definition")
-		for _, credential := range input.Credentials {
-			entry := make(map[string]any)
-			for k, v := range credential {
-				// Updater does not get credentials.
-				if k != "token" && k != "password" && k != "key" && k != "auth-key" {
-					entry[k] = v
-				}
+	// Calculate the credentials-metadata as it cannot be provided by the user anymore.
+	for _, credential := range input.Credentials {
+		entry := make(map[string]any)
+		for k, v := range credential {
+			// Updater does not get credentials.
+			if k != "token" && k != "password" && k != "key" && k != "auth-key" {
+				entry[k] = v
 			}
-			input.Job.CredentialsMetadata = append(input.Job.CredentialsMetadata, entry)
 		}
+		input.Job.CredentialsMetadata = append(input.Job.CredentialsMetadata, entry)
 	}
 }
 

--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -363,11 +363,12 @@ func processInput(input *model.Input, flags *UpdateFlags) {
 	}
 
 	// Calculate the credentials-metadata as it cannot be provided by the user anymore.
+	input.Job.CredentialsMetadata = []model.Credential{}
 	for _, credential := range input.Credentials {
 		entry := make(map[string]any)
 		for k, v := range credential {
 			// Updater does not get credentials.
-			if k != "token" && k != "password" && k != "key" && k != "auth-key" {
+			if k != "username" && k != "token" && k != "password" && k != "key" && k != "auth-key" {
 				entry[k] = v
 			}
 		}

--- a/cmd/dependabot/internal/cmd/update_test.go
+++ b/cmd/dependabot/internal/cmd/update_test.go
@@ -35,8 +35,6 @@ func Test_processInput(t *testing.T) {
 	t.Run("adds git_source to credentials when local token is present", func(t *testing.T) {
 		var input model.Input
 		os.Setenv("LOCAL_GITHUB_ACCESS_TOKEN", "token")
-		// Adding a dummy metadata to test the inner if
-		input.Job.CredentialsMetadata = []model.Credential{{}}
 
 		processInput(&input, nil)
 
@@ -51,7 +49,7 @@ func Test_processInput(t *testing.T) {
 		}) {
 			t.Error("expected credentials to be added")
 		}
-		if !reflect.DeepEqual(input.Job.CredentialsMetadata[1], model.Credential{
+		if !reflect.DeepEqual(input.Job.CredentialsMetadata[0], model.Credential{
 			"type": "git_source",
 			"host": "github.com",
 		}) {

--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -47,7 +47,7 @@ type Job struct {
 	RejectExternalCode         bool              `json:"reject-external-code" yaml:"reject-external-code,omitempty"`
 	RepoPrivate                bool              `json:"repo-private" yaml:"repo-private,omitempty"`
 	CommitMessageOptions       *CommitOptions    `json:"commit-message-options" yaml:"commit-message-options,omitempty"`
-	CredentialsMetadata        []Credential      `json:"credentials-metadata" yaml:"credentials-metadata,omitempty"`
+	CredentialsMetadata        []Credential      `json:"credentials-metadata" yaml:"-"`
 	MaxUpdaterRunTime          int               `json:"max-updater-run-time" yaml:"max-updater-run-time,omitempty"`
 }
 

--- a/internal/model/job_test.go
+++ b/internal/model/job_test.go
@@ -338,9 +338,6 @@ job:
   - name: npm
     rules:
       patterns: ["npm", "@npmcli*"]
-  credentials-metadata:
-  - type: git_source
-    host: github.com
   security-advisories:
   - dependency-name: got
     patched-versions: []


### PR DESCRIPTION
Currently in the job definition there is a `credentials-metadata` which is derived from the `credentials` which are sent to the Proxy. Since it can always be derived from `credentials` then there's no reason it needs to be provided separately. It should help to prevent mistakes by not reading it.

Also noticed that `username` is also not provided by the dependabot-api so removed it as well.