### PR TITLE
silence git's info on default branches

### DIFF
--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -448,6 +448,7 @@ func putCloneDir(ctx context.Context, cli *client.Client, updater *Updater, dir 
 	// The directory needs to be a git repo, so we need to initialize it.
 	commands := []string{
 		"cd " + guestRepoDir,
+		"git config --global init.defaultBranch main",
 		"git init",
 		"git config user.email 'dependabot@github.com'",
 		"git config user.name 'dependabot'",


### PR DESCRIPTION
When using the `--local` flag, git outputs a lecture on how to set the default branch name. 

This PR sets the default branch name to suppress that output.