### PR TITLE
match the API with how blank directory is handled

### DIFF
--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -55,7 +55,7 @@ type Job struct {
 type Source struct {
 	Provider    string   `json:"provider" yaml:"provider,omitempty"`
 	Repo        string   `json:"repo" yaml:"repo,omitempty"`
-	Directory   string   `json:"directory" yaml:"directory,omitempty"`
+	Directory   string   `json:"directory,omitempty" yaml:"directory,omitempty"`
 	Directories []string `json:"directories,omitempty" yaml:"directories,omitempty"`
 	Branch      string   `json:"branch,omitempty" yaml:"branch,omitempty"`
 	Commit      string   `json:"commit,omitempty" yaml:"commit,omitempty"`


### PR DESCRIPTION
For a group security update, a nil directory is sent by the API. The CLI was sending a blank string.