### PR TITLE
Increase OpenTelemetry collector timeout from 5 to 30 seconds

### DIFF
--- a/internal/infra/open_telemetry.go
+++ b/internal/infra/open_telemetry.go
@@ -106,7 +106,7 @@ func NewCollector(ctx context.Context, cli *client.Client, net *Networks, params
 
 // Close stops and removes the container.
 func (c *Collector) Close() error {
-	timeout := 5
+	timeout := 30
 	_ = c.cli.ContainerStop(context.Background(), c.containerID, container.StopOptions{Timeout: &timeout})
 
 	err := c.cli.ContainerRemove(context.Background(), c.containerID, types.ContainerRemoveOptions{Force: true})


### PR DESCRIPTION
We've seen that 5 seconds is sometimes not enough time to propagate logs upstream, especially if there is a large batch cached locally. Increasing this from 5 to 30 seconds should (hopefully!) resolve the issue.