### PR TITLE
Insert the correct Azure Artifacts credential type for the job package manager

### DIFF
--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -39,7 +39,7 @@ type UpdateFlags struct {
 }
 
 // A map of package manager names to credential type
-var packageManagerCredentialType = map[string]string{
+var azureArtifactsPackageManagerCredentialType = map[string]string{
 	"gradle":       "maven_repository",
 	"maven":        "maven_repository",
 	"npm_and_yarn": "npm_registry",
@@ -345,7 +345,7 @@ func processInput(input *model.Input, flags *UpdateFlags) {
 		}
 
 		// Add the Azure Artifacts credentials for each host if the package manager is supported.
-		if _, ok := packageManagerCredentialType[input.Job.PackageManager]; ok {
+		if _, ok := azureArtifactsPackageManagerCredentialType[input.Job.PackageManager]; ok {
 			// All Azure Artifacts hosts
 			azureArtifactsHosts := []string{
 				"pkgs.dev.azure.com",
@@ -353,7 +353,7 @@ func processInput(input *model.Input, flags *UpdateFlags) {
 			}
 			for _, host := range azureArtifactsHosts {
 				input.Credentials = append(input.Credentials, model.Credential{
-					"type":     packageManagerCredentialType[input.Job.PackageManager],
+					"type":     azureArtifactsPackageManagerCredentialType[input.Job.PackageManager],
 					"host":     host,
 					"username": "x-access-token",
 					"password": "$LOCAL_AZURE_ACCESS_TOKEN",
@@ -361,7 +361,7 @@ func processInput(input *model.Input, flags *UpdateFlags) {
 				if len(input.Job.CredentialsMetadata) > 0 {
 					// Add the metadata since the next section will be skipped.
 					input.Job.CredentialsMetadata = append(input.Job.CredentialsMetadata, map[string]any{
-						"type": packageManagerCredentialType[input.Job.PackageManager],
+						"type": azureArtifactsPackageManagerCredentialType[input.Job.PackageManager],
 						"host": host,
 					})
 				}

--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -38,6 +38,15 @@ type UpdateFlags struct {
 	apiUrl          string
 }
 
+// A map of package manager names to credential type
+var packageManagerCredentialType = map[string]string{
+	"gradle":       "maven_repository",
+	"maven":        "maven_repository",
+	"npm_and_yarn": "npm_registry",
+	"nuget":        "nuget_feed",
+	"pip":          "python_index",
+}
+
 func NewUpdateCommand() *cobra.Command {
 	var flags UpdateFlags
 
@@ -334,31 +343,28 @@ func processInput(input *model.Input, flags *UpdateFlags) {
 				"host": "dev.azure.com",
 			})
 		}
-		input.Credentials = append(input.Credentials, model.Credential{
-			"type":     "git_source",
-			"host":     fmt.Sprintf("%s.pkgs.visualstudio.com", azureRepo.Org),
-			"username": "x-access-token",
-			"password": "$LOCAL_AZURE_ACCESS_TOKEN",
-		})
-		if len(input.Job.CredentialsMetadata) > 0 {
-			// Add the metadata since the next section will be skipped.
-			input.Job.CredentialsMetadata = append(input.Job.CredentialsMetadata, map[string]any{
-				"type": "git_source",
-				"host": fmt.Sprintf("%s.pkgs.visualstudio.com", azureRepo.Org),
-			})
+
+		// All Azure Artifacts hosts
+		azureArtifactsHosts := []string{
+			"pkgs.dev.azure.com",
+			fmt.Sprintf("%s.pkgs.visualstudio.com", azureRepo.Org),
 		}
-		input.Credentials = append(input.Credentials, model.Credential{
-			"type":     "git_source",
-			"host":     "pkgs.dev.azure.com",
-			"username": "x-access-token",
-			"password": "$LOCAL_AZURE_ACCESS_TOKEN",
-		})
-		if len(input.Job.CredentialsMetadata) > 0 {
-			// Add the metadata since the next section will be skipped.
-			input.Job.CredentialsMetadata = append(input.Job.CredentialsMetadata, map[string]any{
-				"type": "git_source",
-				"host": "pkgs.dev.azure.com",
+
+		// Add the Azure Artifacts credentials for each host
+		for _, host := range azureArtifactsHosts {
+			input.Credentials = append(input.Credentials, model.Credential{
+				"type":     packageManagerCredentialType[input.Job.PackageManager],
+				"host":     host,
+				"username": "x-access-token",
+				"password": "$LOCAL_AZURE_ACCESS_TOKEN",
 			})
+			if len(input.Job.CredentialsMetadata) > 0 {
+				// Add the metadata since the next section will be skipped.
+				input.Job.CredentialsMetadata = append(input.Job.CredentialsMetadata, map[string]any{
+					"type": packageManagerCredentialType[input.Job.PackageManager],
+					"host": host,
+				})
+			}
 		}
 	}
 

--- a/cmd/dependabot/internal/cmd/update_test.go
+++ b/cmd/dependabot/internal/cmd/update_test.go
@@ -110,6 +110,7 @@ func Test_processInput(t *testing.T) {
 		var flags = UpdateFlags{
 			apiUrl: "https://dev.azure.com/org/project/_git/repo",
 		}
+		os.Unsetenv("LOCAL_GITHUB_ACCESS_TOKEN")
 		os.Setenv("LOCAL_AZURE_ACCESS_TOKEN", "token")
 
 		processInput(&input, &flags)

--- a/cmd/dependabot/internal/cmd/update_test.go
+++ b/cmd/dependabot/internal/cmd/update_test.go
@@ -92,6 +92,34 @@ func Test_processInput(t *testing.T) {
 			t.Error("expected credentials metadata to be added")
 		}
 	})
+
+	t.Run("add Azure credentials when local token is present", func(t *testing.T) {
+		var input = model.Input{
+			Job: model.Job{
+				PackageManager: "nuget",
+				Source: model.Source{
+					Repo:      "org/project/_git/repo",
+					Directory: "/",
+				},
+			},
+		}
+		var flags = UpdateFlags{
+			apiUrl: "https://dev.azure.com/org/project/_git/repo",
+		}
+		os.Setenv("LOCAL_AZURE_ACCESS_TOKEN", "token")
+
+		processInput(&input, &flags)
+
+		if len(input.Credentials) != 4 {
+			t.Fatal("expected credentials to be added")
+		}
+		// Ensure all credentials are either git_source or azure
+		for _, cred := range input.Credentials {
+			if cred["type"] != "git_source" && cred["type"] != "nuget_feed" {
+				t.Errorf("expected credentials to be either git_source or nuget_feed, got %s", cred["type"])
+			}
+		}
+	})
 }
 
 func Test_extractInput(t *testing.T) {

--- a/cmd/dependabot/internal/cmd/update_test.go
+++ b/cmd/dependabot/internal/cmd/update_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 func Test_processInput(t *testing.T) {
+	t.Cleanup(func() {
+		os.Unsetenv("LOCAL_GITHUB_ACCESS_TOKEN")
+		os.Unsetenv("LOCAL_GITHUB_ACCESS_TOKEN")
+	})
 	t.Run("initializes some fields", func(t *testing.T) {
 		os.Setenv("LOCAL_GITHUB_ACCESS_TOKEN", "")
 

--- a/cmd/dependabot/internal/cmd/update_test.go
+++ b/cmd/dependabot/internal/cmd/update_test.go
@@ -14,7 +14,7 @@ import (
 func Test_processInput(t *testing.T) {
 	t.Cleanup(func() {
 		os.Unsetenv("LOCAL_GITHUB_ACCESS_TOKEN")
-		os.Unsetenv("LOCAL_GITHUB_ACCESS_TOKEN")
+		os.Unsetenv("LOCAL_AZURE_ACCESS_TOKEN")
 	})
 	t.Run("initializes some fields", func(t *testing.T) {
 		os.Setenv("LOCAL_GITHUB_ACCESS_TOKEN", "")


### PR DESCRIPTION
Previously the credentials for `<org>.pkgs.visualstudio.com` and `pkgs.dev.azure.com` were added as `git_source`. But these hostnames actually serve package registries, not git. Git source hostnames are **only** `<org>.visualstudio.com` and `dev.azure.com`.