### PR TITLE
Do not pass credentials metadata from Azure Artifacts

### DIFF
--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -358,13 +358,6 @@ func processInput(input *model.Input, flags *UpdateFlags) {
 					"username": "x-access-token",
 					"password": "$LOCAL_AZURE_ACCESS_TOKEN",
 				})
-				if len(input.Job.CredentialsMetadata) > 0 {
-					// Add the metadata since the next section will be skipped.
-					input.Job.CredentialsMetadata = append(input.Job.CredentialsMetadata, map[string]any{
-						"type": azureArtifactsPackageManagerCredentialType[input.Job.PackageManager],
-						"host": host,
-					})
-				}
 			}
 		} else {
 			log.Printf("Skipping Azure Artifacts credentials for %s package manager.", input.Job.PackageManager)


### PR DESCRIPTION
For Azure Artifacts registries we configure credentials with a `host` as we cannot know ahead of time the exact URL of the registry. This means the credential metadata isn't useful to the updater, and can cause runtime issues.