### PR TITLE
Bump go from `1.22.0` to `1.22.1`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version-file: go.mod
 
       - name: Build
         run: go build -v ./...
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version-file: go.mod
 
       - name: Run go vet
         run: go vet ./...

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
     # The runner ships with v1.20.14
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version-file: go.mod
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: wangyoucao577/go-release-action@v1.49
         with:
-          goversion: 1.22.1 # needs the patch specified
+          goversion: go.mod
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: wangyoucao577/go-release-action@v1.49
         with:
-          goversion: 1.22.0 # needs the patch specified
+          goversion: 1.22.1 # needs the patch specified
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version-file: go.mod
 
       # Download the Proxy cache. The job is ideally 100% cached so no real calls are made.
       - name: Download cache

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dependabot/cli
 
-go 1.22
+go 1.22.1
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0


### PR DESCRIPTION
This resolves:

- CVE-2024-24783
- CVE-2023-45290
- CVE-2023-45289

See https://go.dev/doc/devel/release#go1.22.1