### PR TITLE
add flag to request and gather a flamegraph

### DIFF
--- a/cmd/dependabot/internal/cmd/root.go
+++ b/cmd/dependabot/internal/cmd/root.go
@@ -15,6 +15,7 @@ type SharedFlags struct {
 	file                string
 	cache               string
 	debugging           bool
+	flamegraph          bool
 	proxyCertPath       string
 	collectorConfigPath string
 	extraHosts          []string

--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -86,6 +86,7 @@ func NewUpdateCommand() *cobra.Command {
 				CollectorImage:      collectorImage,
 				Creds:               input.Credentials,
 				Debug:               flags.debugging,
+				Flamegraph:          flags.flamegraph,
 				Expected:            nil, // update subcommand doesn't use expectations
 				ExtraHosts:          flags.extraHosts,
 				InputName:           flags.file,
@@ -126,6 +127,7 @@ func NewUpdateCommand() *cobra.Command {
 	cmd.Flags().StringVar(&flags.collectorConfigPath, "collector-config", "", "path to an OpenTelemetry collector config file")
 	cmd.Flags().BoolVar(&flags.pullImages, "pull", true, "pull the image if it isn't present")
 	cmd.Flags().BoolVar(&flags.debugging, "debug", false, "run an interactive shell inside the updater")
+	cmd.Flags().BoolVar(&flags.flamegraph, "flamegraph", false, "generate a flamegraph and other metrics")
 	cmd.Flags().StringArrayVarP(&flags.volumes, "volume", "v", nil, "mount volumes in Docker")
 	cmd.Flags().StringArrayVar(&flags.extraHosts, "extra-hosts", nil, "Docker extra hosts setting on the proxy")
 	cmd.Flags().DurationVarP(&flags.timeout, "timeout", "t", 0, "max time to run an update")

--- a/testdata/scripts/flamegraph.txt
+++ b/testdata/scripts/flamegraph.txt
@@ -1,0 +1,32 @@
+# Build the dummy Dockerfile
+exec docker build -qt flamegraph-updater .
+
+# Run the dependabot command
+dependabot update go_modules dependabot/cli --updater-image flamegraph-updater --flamegraph
+
+# There should be a flamegraph file in the current directory
+exists flamegraph.html
+
+exec docker rmi -f flamegraph-updater
+
+-- Dockerfile --
+FROM ubuntu:22.04
+
+RUN useradd dependabot
+
+COPY --chown=dependabot --chmod=755 update-ca-certificates /usr/bin/update-ca-certificates
+COPY --chown=dependabot --chmod=755 run bin/run
+
+-- update-ca-certificates --
+#!/usr/bin/env bash
+
+echo "Updated those certificates for ya"
+
+-- run --
+#!/usr/bin/env bash
+
+# if there's an environment variable "FLAMEGRAPH" set, create a fake flamegraph in tmp
+if [ -n "$FLAMEGRAPH" ]; then
+  echo "Creating flamegraph"
+  echo "fake flamegraph" > /tmp/dependabot-flamegraph.html
+fi


### PR DESCRIPTION
When a customer is having performance issues for a private repo it would be nice to ask them to run `dependabot update <ecosystem> <org>/<repo> --flamegraph` to gather a flamegraph and send it to us.

So this PR adds that ability from the CLI side.