### PR TITLE
fix WSL "connection refused" to the fake API

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -43,7 +43,7 @@ func NewAPI(expected []model.Output, writer io.Writer) *API {
 	fakeAPIHost := "127.0.0.1"
 	if runtime.GOOS == "linux" {
 		fakeAPIHost = "0.0.0.0"
-		// if running on WSL set the host back to 127.0.0.1 because 0.0.0.0 doesn't work
+		// if running on WSL, 0.0.0.0 doesn't work
 		if version, err := os.ReadFile("/proc/version"); err == nil && strings.Contains(string(version), "Microsoft") {
 			fakeAPIHost = "127.0.0.1"
 		}

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -44,6 +44,10 @@ func NewAPI(expected []model.Output, writer io.Writer) *API {
 	if runtime.GOOS == "linux" {
 		fakeAPIHost = "0.0.0.0"
 	}
+	// if running on WSL set the host back to 127.0.0.1
+	if version, err := os.ReadFile("/proc/version"); err == nil && strings.Contains(string(version), "Microsoft") {
+		fakeAPIHost = "127.0.0.1"
+	}
 	if os.Getenv("FAKE_API_HOST") != "" {
 		fakeAPIHost = os.Getenv("FAKE_API_HOST")
 	}

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -43,10 +43,10 @@ func NewAPI(expected []model.Output, writer io.Writer) *API {
 	fakeAPIHost := "127.0.0.1"
 	if runtime.GOOS == "linux" {
 		fakeAPIHost = "0.0.0.0"
-	}
-	// if running on WSL set the host back to 127.0.0.1
-	if version, err := os.ReadFile("/proc/version"); err == nil && strings.Contains(string(version), "Microsoft") {
-		fakeAPIHost = "127.0.0.1"
+		// if running on WSL set the host back to 127.0.0.1 because 0.0.0.0 doesn't work
+		if version, err := os.ReadFile("/proc/version"); err == nil && strings.Contains(string(version), "Microsoft") {
+			fakeAPIHost = "127.0.0.1"
+		}
 	}
 	if os.Getenv("FAKE_API_HOST") != "" {
 		fakeAPIHost = os.Getenv("FAKE_API_HOST")


### PR DESCRIPTION
By default the CLI starts a fake API server which intercepts calls to a real API which allows the CLI to print output to stdout or a file.

Unfortunately on Linux, Docker won't allow a container to communicate with a server running on the host on 127.0.0.1, so we had to set it to 0.0.0.0. 

Even more unfortunate, is on WSL which is a Linux variant, 0.0.0.0 doesn't work at all so we have to set it back to 127.0.0.1. 

Using the info in https://github.com/microsoft/WSL/issues/423#issuecomment-221627364 to detect WSL.