### PR TITLE
hack: dependabot ls command

### DIFF
--- a/cmd/dependabot/internal/cmd/ls.go
+++ b/cmd/dependabot/internal/cmd/ls.go
@@ -63,7 +63,7 @@ func NewListCommand() *cobra.Command {
 				// HACK: we cancel context to stop the containers, so we don't know if there was a failure.
 				// A correct solution would involve changes with dependabot-core, which is good, but
 				// I am just hacking this together right now.
-				// log.Fatalf("updater failure: %v", err)
+				log.Printf("HACK: suppressing updater failure: %v", err)
 				return nil
 			}
 

--- a/cmd/dependabot/internal/cmd/ls.go
+++ b/cmd/dependabot/internal/cmd/ls.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"github.com/MakeNowJust/heredoc"
+	"github.com/dependabot/cli/internal/infra"
+	"github.com/spf13/cobra"
+	"log"
+)
+
+var listCmd = NewListCommand()
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+}
+
+func NewListCommand() *cobra.Command {
+	var flags UpdateFlags
+
+	cmd := &cobra.Command{
+		Use:   "ls [<package_manager> <repo>] [flags]",
+		Short: "List the dependencies of a manifest/lockfile",
+		Example: heredoc.Doc(`
+		    $ dependabot ls go_modules rsc/quote
+		    $ dependabot ls go_modules --local .
+	    `),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			input, err := readArguments(cmd, &flags)
+			if err != nil {
+				return err
+			}
+
+			processInput(input, &flags)
+
+			input.Job.Source.Provider = "github" // TODO why isn't this being set?
+
+			if err := infra.Run(infra.RunParams{
+				CacheDir:            flags.cache,
+				CollectorConfigPath: flags.collectorConfigPath,
+				CollectorImage:      collectorImage,
+				Creds:               input.Credentials,
+				Debug:               flags.debugging,
+				Flamegraph:          flags.flamegraph,
+				Expected:            nil, // update subcommand doesn't use expectations
+				ExtraHosts:          flags.extraHosts,
+				InputName:           flags.file,
+				Job:                 &input.Job,
+				ListDependencies:    true, // list dependencies, then exit
+				LocalDir:            flags.local,
+				Output:              flags.output,
+				ProxyCertPath:       flags.proxyCertPath,
+				ProxyImage:          proxyImage,
+				PullImages:          flags.pullImages,
+				Timeout:             flags.timeout,
+				UpdaterImage:        updaterImage,
+				Volumes:             flags.volumes,
+				Writer:              nil, // prevent outputting all API responses to stdout, we only want dependencies
+			}); err != nil {
+				if errors.Is(err, context.DeadlineExceeded) {
+					log.Fatalf("update timed out after %s", flags.timeout)
+				}
+				// HACK: we cancel context to stop the containers, so we don't know if there was a failure.
+				// A correct solution would involve changes with dependabot-core, which is good, but
+				// I am just hacking this together right now.
+				// log.Fatalf("updater failure: %v", err)
+				return nil
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&flags.branch, "branch", "b", "", "target branch to update")
+	cmd.Flags().StringVarP(&flags.directory, "directory", "d", "/", "directory to update")
+	cmd.Flags().StringVarP(&flags.commit, "commit", "", "", "commit to update")
+
+	cmd.Flags().StringVarP(&flags.output, "output", "o", "", "write scenario to file")
+	cmd.Flags().StringVar(&flags.cache, "cache", "", "cache import/export directory")
+	cmd.Flags().StringVar(&flags.local, "local", "", "local directory to use as fetched source")
+	cmd.Flags().StringVar(&flags.proxyCertPath, "proxy-cert", "", "path to a certificate the proxy will trust")
+	cmd.Flags().StringVar(&flags.collectorConfigPath, "collector-config", "", "path to an OpenTelemetry collector config file")
+	cmd.Flags().BoolVar(&flags.pullImages, "pull", true, "pull the image if it isn't present")
+	cmd.Flags().BoolVar(&flags.debugging, "debug", false, "run an interactive shell inside the updater")
+	cmd.Flags().BoolVar(&flags.flamegraph, "flamegraph", false, "generate a flamegraph and other metrics")
+	cmd.Flags().StringArrayVarP(&flags.volumes, "volume", "v", nil, "mount volumes in Docker")
+	cmd.Flags().StringArrayVar(&flags.extraHosts, "extra-hosts", nil, "Docker extra hosts setting on the proxy")
+	cmd.Flags().DurationVarP(&flags.timeout, "timeout", "t", 0, "max time to run an update")
+
+	return cmd
+}

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -35,6 +35,8 @@ type RunParams struct {
 	Job *model.Job
 	// expectations asserted at the end of a test
 	Expected []model.Output
+	// if true, the containers will be stopped once the dependencies are listed
+	ListDependencies bool
 	// directory to copy into the updater container as the repo
 	LocalDir string
 	// credentials passed to the proxy
@@ -106,6 +108,19 @@ func Run(params RunParams) error {
 
 	api := server.NewAPI(params.Expected, params.Writer)
 	defer api.Stop()
+
+	if params.ListDependencies {
+		go func() {
+			dependencyList := <-api.UpdateDependencyList
+			encoder := json.NewEncoder(os.Stdout)
+			encoder.SetIndent("", "  ")
+			err := encoder.Encode(dependencyList.Dependencies)
+			if err != nil {
+				log.Printf("failed to write dependency list: %v\n", err)
+			}
+			cancel()
+		}()
+	}
 
 	var outFile *os.File
 	if params.Output != "" {


### PR DESCRIPTION
This adds the `dependabot ls` command which outputs the parsed dependencies, and then stops the containers:

```console
$ dependabot ls go_modules dependabot/cli 2> /dev/null
[
  {
    "name": "github.com/MakeNowJust/heredoc",
    "requirements": [
      {
        "file": "go.mod",
        "groups": [],
        "requirement": "v1.0.0",
        "source": {
          "source": "github.com/MakeNowJust/heredoc",
          "type": "default"
        }
      }
    ],
    "version": "1.0.0"
  },
... (and so on for a while)
```

The reason this is labelled as a hack is the Dependabot Updater wants to continue with the update, but I have the CLI cancel the Context which terminates the Docker containers. 

A more graceful solution would involve telling dependabot-core directly that we want to stop after the dependencies are gathered.

For now this works as a POC.

In the console command above, I've redirected stderr to /dev/null as by default the Dependabot CLI outputs logs to stderr.