### PR TITLE
Add `dotnet-sdk` support

### DIFF
--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -251,6 +251,7 @@ var packageManagerLookup = map[string]string{
 	"composer":       "composer",
 	"pub":            "pub",
 	"docker":         "docker",
+	"dotnet_sdk":     "dotnet-sdk",
 	"elm":            "elm",
 	"github_actions": "github-actions",
 	"submodules":     "gitsubmodule",


### PR DESCRIPTION
Initial support for the .NET SDK package manager. See https://github.com/dependabot/dependabot-core/pull/10756