### PR TITLE
add alternate azure git repo urls to credentials for submodules

### DIFF
--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -332,19 +332,20 @@ func processInput(input *model.Input, flags *UpdateFlags) {
 	if hasLocalAzureToken && !isGitSourceInCreds && azureRepo != nil {
 		log.Println("Inserting $LOCAL_AZURE_ACCESS_TOKEN into credentials")
 		log.Printf("Inserting artifacts credentials for %s organization.", azureRepo.Org)
+
+		// add both `dev.azure.com` and `org.visualstudio.com` credentials
 		input.Credentials = append(input.Credentials, model.Credential{
 			"type":     "git_source",
 			"host":     "dev.azure.com",
 			"username": "x-access-token",
 			"password": "$LOCAL_AZURE_ACCESS_TOKEN",
 		})
-		if len(input.Job.CredentialsMetadata) > 0 {
-			// Add the metadata since the next section will be skipped.
-			input.Job.CredentialsMetadata = append(input.Job.CredentialsMetadata, map[string]any{
-				"type": "git_source",
-				"host": "dev.azure.com",
-			})
-		}
+		input.Credentials = append(input.Credentials, model.Credential{
+			"type":     "git_source",
+			"host":     fmt.Sprintf("%s.visualstudio.com", azureRepo.Org),
+			"username": "x-access-token",
+			"password": "$LOCAL_AZURE_ACCESS_TOKEN",
+		})
 	}
 
 	// Calculate the credentials-metadata as it cannot be provided by the user anymore.


### PR DESCRIPTION
When a job is started with the `azure` provider, `git_source` credentials are provided for the `dev.azure.com` domain and that URL is ultimately used to clone the repo.

If a repo has a submodule and specifies the URL with the `dev.azure.com` format, everything is OK because the credentials are properly injected by the proxy, but there is an alternate format that's not handled: `org.visualstudio.com/DefaultCollection/project/_git/repo` and if a submodule clone is attempted with that URL, it's not detected as being functionally the same as the other URL and a `401` is returned, possibly making the job fail due to missing sources.

This PR adds the alternate `org.visualstudio.com` credentials.

A manual test was performed, first with the old behavior ensuring the `401` and again with the new behavior ensuring a correct `200` when cloning the submodule.