### PR TITLE
Always write the update output file, even on container failure

### DIFF
--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -150,7 +150,7 @@ func Run(params RunParams) error {
 		return diff(params, outFile, output)
 	}
 
-	// if the containers failed, poperagate the error
+	// if the containers failed, propagate the error
 	if runContainersErr != nil {
 		return runContainersErr
 	}

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -6,16 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
-	"log"
-	"net/http"
-	"os"
-	"os/signal"
-	"regexp"
-	"strings"
-	"syscall"
-	"time"
-
 	"github.com/dependabot/cli/internal/model"
 	"github.com/dependabot/cli/internal/server"
 	"github.com/docker/docker/api/types"
@@ -27,6 +17,15 @@ import (
 	"github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/client"
 	"gopkg.in/yaml.v3"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"regexp"
+	"strings"
+	"syscall"
+	"time"
 )
 
 type RunParams struct {
@@ -150,12 +149,7 @@ func Run(params RunParams) error {
 		return diff(params, outFile, output)
 	}
 
-	// if the containers failed, propagate the error
-	if runContainersErr != nil {
-		return runContainersErr
-	}
-
-	return nil
+	return runContainersErr
 }
 
 func generateOutput(params RunParams, api *server.API, outFile *os.File) ([]byte, error) {


### PR DESCRIPTION
If there are successful update outputs, it would be useful if Dependabot wrote them to the output file so that the caller can process them, even if the overall update process encountered errors.

This was encountered when testing https://github.com/dependabot/dependabot-core/issues/10834 and also in the tinglesoftware/dependabot-azure-devops implementation of Dependabot for Azure DevOps, see https://github.com/tinglesoftware/dependabot-azure-devops/issues/1407#issuecomment-2419304279.

When this happens...

```log
updater | +------------------------------------------------------------------------------------------------------------------------------------+
updater | |                                                Changes to Dependabot Pull Requests                                                 |
updater | +---------+--------------------------------------------------------------------------------------------------------------------------+
updater | | created | Microsoft.Extensions.DependencyInjection ( from 8.0.0 to 8.0.1 ), Microsoft.Extensions.Logging ( from 8.0.0 to 8.0.1 ... |
updater | +---------+--------------------------------------------------------------------------------------------------------------------------+
updater | Dependabot encountered '1' error(s) during execution, please check the logs for more details.
updater | +-----------------------------------------------------------------+
updater | |                  Dependencies failed to update                  |
updater | +-------------------------------------------+---------------------+
updater | | Microsoft.Extensions.Logging.Abstractions | update_not_possible |
updater | +-------------------------------------------+---------------------+
```

The "create_pull_request" output for the successful update could still be processed by the caller, if CLI wrote the output file.
After this change, the outputs from a partially successful Dependabot update can still be processed whilst also still reporting that the overall update failed.