### PR TITLE
use new build version feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # To make the `dependabot --version` test succeed we must not be in a detached HEAD state.
-      - run: git checkout -b local-branch-for-testing
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Build
-        run: go version && go build -v ./...
+        run: go version && go build -v ./... && dependabot --version
 
       - name: Test
         # -count=2 ensures that test fixtures cleanup after themselves

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,6 @@ jobs:
       - name: Build
         run: go version && go build -v ./...
 
-      - name: Check dependabot version
-        run: go install github.com/dependabot/cli/cmd/dependabot && dependabot --version
-
       - name: Test
         # -count=2 ensures that test fixtures cleanup after themselves
         # because any leftover state will generally cause the second run to fail.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,10 @@ jobs:
           go-version-file: go.mod
 
       - name: Build
-        run: go version && go build -v ./... && dependabot --version
+        run: go version && go build -v ./...
+
+      - name: Check dependabot version
+        run: go install github.com/dependabot/cli/cmd/dependabot && dependabot --version
 
       - name: Test
         # -count=2 ensures that test fixtures cleanup after themselves

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # To make the `dependabot --version` test succeed we must not be in a detached HEAD state.
+      - run: git checkout -b local-branch-for-testing
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Build
-        run: go build -v ./...
+        run: go version && go build -v ./...
 
       - name: Test
         # -count=2 ensures that test fixtures cleanup after themselves

--- a/README.md
+++ b/README.md
@@ -18,11 +18,7 @@ Use any of the following for a pain-free installation:
    ```
    The benefit of this method is that re-running the command will always update to the latest version.
 * You can download a pre-built binary from the [releases] page.
-* If you have the [`gh`][gh] command available, you can install the latest release
-   of `dependabot` using the following command ([gist source](https://gist.github.com/mattt/e09e1ecd76d5573e0517a7622009f06f)):
-   ```shell
-   gh gist view --raw e09e1ecd76d5573e0517a7622009f06f | bash
-   ```
+* On Mac, you can run `brew install dependabot`
 
 ## Requirements
 

--- a/cmd/dependabot/dependabot_test.go
+++ b/cmd/dependabot/dependabot_test.go
@@ -26,13 +26,8 @@ func TestDependabot(t *testing.T) {
 		Cmds:  Commands(),
 		Quiet: !testing.Verbose(),
 	}
-	// adding this path to the PATH so that the dependabot command we just built is used
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
 	env := []string{
-		"PATH=" + wd + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"PATH=" + os.Getenv("PATH"),
 	}
 	scripttest.Test(t, ctx, engine, env, "../../testdata/scripts/*.txt")
 }

--- a/cmd/dependabot/dependabot_test.go
+++ b/cmd/dependabot/dependabot_test.go
@@ -24,7 +24,7 @@ func TestDependabot(t *testing.T) {
 	engine := &script.Engine{
 		Conds: scripttest.DefaultConds(),
 		Cmds:  Commands(),
-		Quiet: !testing.Verbose(),
+		Quiet: false,
 	}
 	env := []string{
 		"PATH=" + os.Getenv("PATH"),

--- a/cmd/dependabot/dependabot_test.go
+++ b/cmd/dependabot/dependabot_test.go
@@ -26,8 +26,13 @@ func TestDependabot(t *testing.T) {
 		Cmds:  Commands(),
 		Quiet: !testing.Verbose(),
 	}
+	// adding this path to the PATH so that the dependabot command we just built is used
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
 	env := []string{
-		"PATH=" + os.Getenv("PATH"),
+		"PATH=" + wd + string(os.PathListSeparator) + os.Getenv("PATH"),
 	}
 	scripttest.Test(t, ctx, engine, env, "../../testdata/scripts/*.txt")
 }

--- a/cmd/dependabot/dependabot_test.go
+++ b/cmd/dependabot/dependabot_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestDependabot(t *testing.T) {
-	err := exec.Command("go", "build", "dependabot.go").Run()
+	err := exec.Command("go", "build", ".").Run()
 	if err != nil {
 		t.Fatal("failed to build dependabot")
 	}

--- a/cmd/dependabot/internal/cmd/version.go
+++ b/cmd/dependabot/internal/cmd/version.go
@@ -1,42 +1,24 @@
 package cmd
 
 import (
-	"fmt"
-	"regexp"
+	"log"
 	"runtime/debug"
 )
 
 // ldflags inserts the version here on release
 var version string
 
-var timestampRegex = regexp.MustCompile("[^a-zA-Z0-9]+")
-
 func Version() string {
 	if version == "" {
 		version = "0.0.0-dev"
-		commit := ""
-		timestamp := ""
-		modified := false
 
-		info, _ := debug.ReadBuildInfo()
-		for _, entry := range info.Settings {
-			if entry.Key == "vcs.revision" && len(entry.Value) >= 7 {
-				commit = entry.Value[:7] // short ref
-			}
-
-			if entry.Key == "vcs.modified" {
-				modified = entry.Value == "true"
-			}
-
-			if entry.Key == "vcs.time" {
-				timestamp = timestampRegex.ReplaceAllString(entry.Value, "")
-			}
+		info, ok := debug.ReadBuildInfo()
+		if !ok {
+			log.Println("debug.ReadBuildInfo failed")
+			return version
 		}
-
-		if modified && timestamp != "" {
-			return fmt.Sprintf("%s+%s", version, timestamp)
-		} else if commit != "" {
-			return fmt.Sprintf("%s+%s", version, commit)
+		if info.Main.Version != "" {
+			version = info.Main.Version
 		}
 	}
 

--- a/testdata/scripts/version.txt
+++ b/testdata/scripts/version.txt
@@ -2,4 +2,4 @@
 dependabot --version
 
 # example: dependabot version v1.57.1-0.20250218140044-2f3fdc69ebfd
-stdout 'dependabot version v1.\d+.\d+-0.\d{14}-[a-f0-9]{12}'
+stdout 'dependabot version v\d+.\d+.\d+-0.\d{14}-[a-f0-9]{12}'

--- a/testdata/scripts/version.txt
+++ b/testdata/scripts/version.txt
@@ -1,0 +1,5 @@
+# Run the dependabot command
+dependabot --version
+
+# example: dependabot version v1.57.1-0.20250218140044-2f3fdc69ebfd
+stdout 'dependabot version v1.\d+.\d+-0.\d{14}-[a-f0-9]{12}'

--- a/testdata/scripts/version.txt
+++ b/testdata/scripts/version.txt
@@ -2,4 +2,4 @@
 dependabot --version
 
 # example: dependabot version v1.57.1-0.20250218140044-2f3fdc69ebfd
-stdout 'dependabot version v\d+.\d+.\d+-0.\d{14}-[a-f0-9]{12}'
+stdout 'dependabot version v\d+.\d+.\d+-(\d+\.)?\d{14}-[a-f0-9]{12}'


### PR DESCRIPTION
Go 1.24 is now injecting the build version into the binary, so we don't need to do this extra work.

I think this may also fix #233, allowing us to ask people to run `dependabot --version` to check to see if they're running an old version of the Dependabot CLI. Currently it does not work if they do the `go install` command.

Also updated the installation instructions, removed a gist from a former employee.