### PR TITLE
Add Bun and Docker Compose package manager lookups

### DIFF
--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -6,6 +6,16 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"regexp"
+	"strings"
+	"syscall"
+	"time"
+
 	"github.com/dependabot/cli/internal/model"
 	"github.com/dependabot/cli/internal/server"
 	"github.com/docker/docker/api/types"
@@ -17,15 +27,6 @@ import (
 	"github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/client"
 	"gopkg.in/yaml.v3"
-	"io"
-	"log"
-	"net/http"
-	"os"
-	"os/signal"
-	"regexp"
-	"strings"
-	"syscall"
-	"time"
 )
 
 type RunParams struct {

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -250,11 +250,13 @@ func checkCredAccess(ctx context.Context, job *model.Job, creds []model.Credenti
 }
 
 var packageManagerLookup = map[string]string{
+	"bun":            "bun",
 	"bundler":        "bundler",
 	"cargo":          "cargo",
 	"composer":       "composer",
 	"pub":            "pub",
 	"docker":         "docker",
+	"docker_compose": "docker-compose",
 	"dotnet_sdk":     "dotnet-sdk",
 	"elm":            "elm",
 	"github_actions": "github-actions",


### PR DESCRIPTION
Part of https://github.com/github/dependabot-updates/issues/7895
Part of https://github.com/github/dependabot-updates/issues/7990

We are adding package manager lookup values for Bun and Docker Compose.

This PR also includes another commit containing linter auto-generated re-org of import statements.