### PR TITLE
test credentials aren't getting into Updater

### DIFF
--- a/testdata/scripts/credentials.txt
+++ b/testdata/scripts/credentials.txt
@@ -1,0 +1,103 @@
+# This test verifies that credentials cannot get into the Updater container, only credential metadata.
+
+exec docker build -qt credentials-verify-updater .
+
+# The custom updater outputs job.json to stderr, so assert the credentials are missing.
+dependabot update -f job1.yml --updater-image credentials-verify-updater
+! stderr 'GPR_TOKEN'
+! stderr '"credentials"'
+! stderr '"github_username"'
+! stderr '"github_password"'
+! stderr 'key'
+stderr '"credentials-metadata"'
+stderr 'npm_registry'
+stderr 'https://npm.pkg.github.com'
+stderr 'github'
+stderr 'hodge-podge'
+
+# This job is invalid: you can't pass credentials key into the job.
+! dependabot update -f job2.yml --updater-image credentials-verify-updater
+stderr 'failed to decode input file'
+
+# This job is invalid: you can't pass credentials-metadata key into the job.
+! dependabot update -f job3.yml --updater-image credentials-verify-updater
+stderr 'failed to decode input file'
+
+exec docker rmi -f credentials-verify-updater
+
+-- job1.yml --
+job:
+  package-manager: npm_and_yarn
+  allowed-updates:
+    - update-type: all
+  source:
+    provider: github
+    repo: dsp-testing/npm-private-registry
+    directory: /consumer
+credentials:
+  - type: npm_registry
+    registry: https://npm.pkg.github.com
+    token: GPR_TOKEN
+  - type: github
+    username: github_username
+    password: github_password
+  - type: hodge-podge
+    key: key
+    auth-key: auth-key
+
+-- job2.yml --
+job:
+  package-manager: npm_and_yarn
+  allowed-updates:
+    - update-type: all
+  source:
+    provider: github
+    repo: dsp-testing/npm-private-registry
+    directory: /consumer
+  # not a valid key for Job
+  credentials:
+    - type: npm_registry
+        registry: https://npm.pkg.github.com
+        token: GPR_TOKEN
+      - type: github
+        username: github_username
+        password: github_password
+
+-- job3.yml --
+job:
+  package-manager: npm_and_yarn
+  allowed-updates:
+    - update-type: all
+  source:
+    provider: github
+    repo: dsp-testing/npm-private-registry
+    directory: /consumer
+  # Not allowed to directly pass in metadata, as it may contain secrets.
+  # You must use credentials which are then scrubbed.
+  credentials-metadata:
+    - type: npm_registry
+        registry: https://npm.pkg.github.com
+        token: GPR_TOKEN
+      - type: github
+        username: github_username
+        password: github_password
+
+-- Dockerfile --
+FROM ubuntu:22.04
+
+RUN useradd dependabot
+
+COPY --chown=dependabot --chmod=755 update-ca-certificates /usr/bin/update-ca-certificates
+COPY --chown=dependabot --chmod=755 run bin/run
+
+-- update-ca-certificates --
+#!/usr/bin/env bash
+
+echo "Updated those certificates for ya"
+
+-- run --
+#!/usr/bin/env bash
+
+echo "Not sure why but unless I echo here the json doesn't output"
+
+cat /home/dependabot/dependabot-updater/job.json


### PR DESCRIPTION
As documented in dependabot-core's README, credentials should not be getting into the Updater container but instead are injected by a Proxy. 

I am adding this test to verify that the credentials aren't getting into the Updater somehow.