### PR TITLE
Add Update Cooldown Parameters to Dependabot CLI

### DIFF
--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -51,6 +51,7 @@ type Job struct {
 	CommitMessageOptions       *CommitOptions    `json:"commit-message-options" yaml:"commit-message-options,omitempty"`
 	CredentialsMetadata        []Credential      `json:"credentials-metadata" yaml:"-"`
 	MaxUpdaterRunTime          int               `json:"max-updater-run-time" yaml:"max-updater-run-time,omitempty"`
+	UpdateCooldown             *UpdateCooldown   `json:"cooldown,omitempty" yaml:"cooldown,omitempty"`
 }
 
 // Source is a reference to some source code
@@ -134,3 +135,12 @@ type CommitOptions struct {
 }
 
 type Credential map[string]any
+
+type UpdateCooldown struct {
+	DefaultDays     int      `json:"default-days,omitempty" yaml:"default-days,omitempty"`
+	SemverMajorDays int      `json:"semver-major-days,omitempty" yaml:"semver-major-days,omitempty"`
+	SemverMinorDays int      `json:"semver-minor-days,omitempty" yaml:"semver-minor-days,omitempty"`
+	SemverPatchDays int      `json:"semver-patch-days,omitempty" yaml:"semver-patch-days,omitempty"`
+	Include         []string `json:"include,omitempty" yaml:"include,omitempty"`
+	Exclude         []string `json:"exclude,omitempty" yaml:"exclude,omitempty"`
+}

--- a/internal/model/job_test.go
+++ b/internal/model/job_test.go
@@ -358,4 +358,15 @@ job:
     include-scope:
   security-updates-only: true
   repo-private: false
+  cooldown:
+    default-days: 3
+    semver-major-days: 7
+    semver-minor-days: 5
+    semver-patch-days: 2
+    include:
+      - dependency-name-1
+      - dependency-name-2
+    exclude:
+      - dependency-name-3
+      - dependency-name-4
 `


### PR DESCRIPTION
#### **Summary**  
This PR adds support for **update cooldown parameters** in the Dependabot CLI. The cooldown settings allow users to configure delays between dependency updates based on semantic versioning rules.

#### **Changes Introduced**  
- Added a new `cooldown` field to the `Job` struct in `model/job.go`, allowing users to specify cooldown settings.
- Updated YAML unmarshaling and struct mapping to support the new `cooldown` parameters.
- Enhanced test coverage in `job_test.go` to validate parsing of cooldown settings from YAML.
- Ensured backward compatibility by making `cooldown` an optional field (`omitempty`).

#### **New Cooldown Parameters**  
- **`default-days`**: Default cooldown period for all updates.
- **`semver-major-days`**: Cooldown period for major updates.
- **`semver-minor-days`**: Cooldown period for minor updates.
- **`semver-patch-days`**: Cooldown period for patch updates.
- **`include`**: List of dependencies explicitly included in cooldown rules.
- **`exclude`**: List of dependencies excluded from cooldown rules.

#### **Why This Change?**  
- Allows users to **reduce update noise** by spacing out dependency updates.
- Provides fine-grained control over update schedules.
- Helps teams **better manage dependency upgrades** without overwhelming PRs.

#### **Testing Done**  
- Added unit tests to `job_test.go` to validate cooldown parameters parsing.
- Verified correct mapping of YAML fields to the `Job` struct.
- Ran `go test ./...` to ensure all tests pass.