### PR TITLE
Add `record_ecosystem_meta` API support

### DIFF
--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -76,13 +76,13 @@ type IncrementMetric struct {
 
 type Ecosystem struct {
 	Name string                   `json:"name" yaml:"name"`
-	PackageManager VersionManager `json:"package_manager" yaml:"package_manager"`
-	Language VersionManager       `json:"language" yaml:"language"`
+	PackageManager VersionManager `json:"package_manager,omitempty" yaml:"package_manager,omitempty"`
+	Language VersionManager       `json:"language,omitempty" yaml:"language,omitempty"`
 }
 
 type VersionManager struct {
 	Name string                `json:"name" yaml:"name"`
 	Version string             `json:"version" yaml:"version"`
 	RawVersion string          `json:"raw_version" yaml:"raw_version"`
-	Requirement map[string]any `json:"requirement" yaml:"requirement"`
+	Requirement map[string]any `json:"requirement,omitempty" yaml:"requirement,omitempty"`
 }

--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -55,6 +55,10 @@ type RecordEcosystemVersions struct {
 	EcosystemVersions map[string]any `json:"ecosystem_versions" yaml:"ecosystem_versions"`
 }
 
+type RecordEcosystemMeta struct {
+	Ecosystem Ecosystem `json:"ecosystem" yaml:"ecosystem"`
+}
+
 type RecordUpdateJobError struct {
 	ErrorType    string         `json:"error-type" yaml:"error-type"`
 	ErrorDetails map[string]any `json:"error-details" yaml:"error-details"`
@@ -68,4 +72,17 @@ type RecordUpdateJobUnknownError struct {
 type IncrementMetric struct {
 	Metric string         `json:"metric" yaml:"metric"`
 	Tags   map[string]any `json:"tags" yaml:"tags"`
+}
+
+type Ecosystem struct {
+	Name string                   `json:"name" yaml:"name"`
+	PackageManager VersionManager `json:"package_manager" yaml:"package_manager"`
+	Language VersionManager       `json:"language" yaml:"language"`
+}
+
+type VersionManager struct {
+	Name string                `json:"name" yaml:"name"`
+	Version string             `json:"version" yaml:"version"`
+	RawVersion string          `json:"raw_version" yaml:"raw_version"`
+	Requirement map[string]any `json:"requirement" yaml:"requirement"`
 }

--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -75,14 +75,14 @@ type IncrementMetric struct {
 }
 
 type Ecosystem struct {
-	Name string                   `json:"name" yaml:"name"`
+	Name           string         `json:"name" yaml:"name"`
 	PackageManager VersionManager `json:"package_manager,omitempty" yaml:"package_manager,omitempty"`
-	Language VersionManager       `json:"language,omitempty" yaml:"language,omitempty"`
+	Language       VersionManager `json:"language,omitempty" yaml:"language,omitempty"`
 }
 
 type VersionManager struct {
-	Name string                `json:"name" yaml:"name"`
-	Version string             `json:"version" yaml:"version"`
-	RawVersion string          `json:"raw_version" yaml:"raw_version"`
+	Name        string         `json:"name" yaml:"name"`
+	Version     string         `json:"version" yaml:"version"`
+	RawVersion  string         `json:"raw_version" yaml:"raw_version"`
 	Requirement map[string]any `json:"requirement,omitempty" yaml:"requirement,omitempty"`
 }

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -235,6 +235,8 @@ func decodeWrapper(kind string, data []byte) (actual *model.UpdateWrapper, err e
 		actual.Data, err = decode[model.MarkAsProcessed](data)
 	case "record_ecosystem_versions":
 		actual.Data, err = decode[model.RecordEcosystemVersions](data)
+	case "record_ecosystem_meta":
+		actual.Data, err = decode[[]model.RecordEcosystemMeta](data)
 	case "record_update_job_error":
 		actual.Data, err = decode[model.RecordUpdateJobError](data)
 	case "record_update_job_unknown_error":


### PR DESCRIPTION
In https://github.com/dependabot/dependabot-core/pull/10905, a new `record_ecosystem_meta` API was added. This API is not implemented by dependabot-cli.

When performing updates for an ecosystem that invokes the API (e.g. pip), the API server will throw 501 errors until updater retry limit is reached:

```log
cli | 2025/03/09 21:40:17 unexpected output type: record_ecosystem_meta
proxy | 2025/03/09 21:40:17 [024] POST http://host.docker.internal:44891/update_jobs/update_0_pip_all/record_ecosystem_meta
proxy | 2025/03/09 21:40:17 [024] 501 http://host.docker.internal:44891/update_jobs/update_0_pip_all/record_ecosystem_meta
cli | 2025/03/09 21:40:22 unexpected output type: record_ecosystem_meta
proxy | 2025/03/09 21:40:22 [025] POST http://host.docker.internal:44891/update_jobs/update_0_pip_all/record_ecosystem_meta
proxy | 2025/03/09 21:40:22 [025] 501 http://host.docker.internal:44891/update_jobs/update_0_pip_all/record_ecosystem_meta
cli | 2025/03/09 21:40:27 unexpected output type: record_ecosystem_meta
proxy | 2025/03/09 21:40:27 [026] POST http://host.docker.internal:44891/update_jobs/update_0_pip_all/record_ecosystem_meta
proxy | 2025/03/09 21:40:27 [026] 501 http://host.docker.internal:44891/update_jobs/update_0_pip_all/record_ecosystem_meta
cli | 2025/03/09 21:40:31 unexpected output type: record_ecosystem_meta
proxy | 2025/03/09 21:40:31 [027] POST http://host.docker.internal:44891/update_jobs/update_0_pip_all/record_ecosystem_meta
proxy | 2025/03/09 21:40:31 [027] 501 http://host.docker.internal:44891/update_jobs/update_0_pip_all/record_ecosystem_meta
updater | 2025/03/09 21:40:31 ERROR <job_update_0_pip_all> Failed to record ecosystem meta after 3 retries
```

This API is called multiple times per dependency update and is compounded by the 3 retries per call. The volume of these errors causes the update process to take significantly longer than normal.

After this change, the API server returns 200 and the updater doesn't report error:

```log
proxy | 2025/03/09 22:15:29 [128] POST http://host.docker.internal:35303/update_jobs/update_0_pip_all/record_ecosystem_meta
proxy | 2025/03/09 22:15:29 [128] 200 http://host.docker.internal:35303/update_jobs/update_0_pip_all/record_ecosystem_meta
```

The output scenario file now contains the `record_ecosystem_meta` data:

![image](https://github.com/user-attachments/assets/62f08a33-f676-464c-a8c8-8a6f90d980ba)
