### PR TITLE
Change type of property `job.commit-message-options.include-scope` to `bool`

### DIFF
--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -129,9 +129,9 @@ type RequirementSource map[string]any
 type Experiment map[string]any
 
 type CommitOptions struct {
-	Prefix            string  `json:"prefix,omitempty" yaml:"prefix,omitempty"`
-	PrefixDevelopment string  `json:"prefix-development,omitempty" yaml:"prefix-development,omitempty"`
-	IncludeScope      *string `json:"include-scope,omitempty" yaml:"include-scope,omitempty"`
+	Prefix            string `json:"prefix,omitempty" yaml:"prefix,omitempty"`
+	PrefixDevelopment string `json:"prefix-development,omitempty" yaml:"prefix-development,omitempty"`
+	IncludeScope      bool   `json:"include-scope,omitempty" yaml:"include-scope,omitempty"`
 }
 
 type Credential map[string]any


### PR DESCRIPTION
Given this `dependabot.yml`:

```yml
version: 2
updates:
  - package-ecosystem: 'nuget'
    directory: '/'
    commit-message:
      include: 'scope'
```

Dependabot-CLI will generate this `job.json`:

```json
{
    "job": {
        "package-manager": "nuget",
        "source": { ...omitted for brevity },
        "commit-message-options": {
            "include-scope": "true"
        }
    }
}
```

After https://github.com/dependabot/dependabot-core/pull/11249 was merged in [v0.292.0](https://github.com/dependabot/dependabot-core/releases/tag/v0.292.0), the above config causes JSON deserialisation errors in the NuGet updater because `include-scope` is expected to be `bool`, not `string`.

Example:
```log
updater | System.Text.Json.JsonException: The JSON value could not be converted to System.Nullable`1[System.Boolean]. Path: $.job.commit-message-options.include-scope | LineNumber: 0 | BytePositionInLine: 1505.
updater |  ---> System.InvalidOperationException: Cannot get the value of a token type 'String' as a boolean.
updater |    at System.Text.Json.ThrowHelper.ThrowInvalidOperationException_ExpectedBoolean(JsonTokenType tokenType)
updater |    at System.Text.Json.Utf8JsonReader.GetBoolean()
updater |    at System.Text.Json.Serialization.Converters.NullableConverter`1.Read(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options)
updater |    at System.Text.Json.Serialization.Metadata.JsonPropertyInfo`1.ReadJsonAndSetMember(Object obj, ReadStack& state, Utf8JsonReader& reader)
updater |    at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
updater |    at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value, Boolean& isPopulatedValue)
updater |    at System.Text.Json.Serialization.Metadata.JsonPropertyInfo`1.ReadJsonAndSetMember(Object obj, ReadStack& state, Utf8JsonReader& reader)
updater |    at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
updater |    at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value, Boolean& isPopulatedValue)
updater |    at System.Text.Json.Serialization.Metadata.JsonPropertyInfo`1.ReadJsonAndSetMember(Object obj, ReadStack& state, Utf8JsonReader& reader)
updater |    at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
updater |    at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value, Boolean& isPopulatedValue)
updater |    at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, T& value, JsonSerializerOptions options, ReadStack& state)
updater |    --- End of inner exception stack trace ---
updater |    at System.Text.Json.ThrowHelper.ReThrowWithPath(ReadStack& state, Utf8JsonReader& reader, Exception ex)
updater |    at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, T& value, JsonSerializerOptions options, ReadStack& state)
updater |    at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1.Deserialize(Utf8JsonReader& reader, ReadStack& state)
updater |    at System.Text.Json.JsonSerializer.ReadFromSpan[TValue](ReadOnlySpan`1 utf8Json, JsonTypeInfo`1 jsonTypeInfo, Nullable`1 actualByteCount)
updater |    at System.Text.Json.JsonSerializer.ReadFromSpan[TValue](ReadOnlySpan`1 json, JsonTypeInfo`1 jsonTypeInfo)
updater |    at NuGetUpdater.Core.Run.RunWorker.Deserialize(String json) in /opt/nuget/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs:line 721
updater |    at NuGetUpdater.Core.ExperimentsManager.FromJobFileAsync(String jobId, String jobFilePath) in /opt/nuget/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs:line 46
```

This change fixes the error by converting the the property to `bool` so that it matches the dependabot-core model:

```json
{
    "job": {
        "package-manager": "nuget",
        "source": { ...omitted for brevity },
        "commit-message-options": {
            "include-scope": true
        }
    }
}
```