### PR TITLE
Tail OpenTelemetry container logs

### DIFF
--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -394,6 +394,9 @@ func runContainers(ctx context.Context, params RunParams) (err error) {
 		if err != nil {
 			fmt.Println("Failed to create OpenTelemetry collector:", err)
 		}
+		if !params.Debug {
+			go collector.TailLogs(ctx, cli)
+		}
 		defer collector.Close()
 	}
 


### PR DESCRIPTION
Similar to the `proxy` and `updater` logs that are emitted from the CLI, this adds the OpenTelemtry container logs as well. For example:

```
otel | 2025-03-24T22:43:22.403Z      info    service@v0.122.1/service.go:193 Setting up own telemetry...
otel | 2025-03-24T22:43:22.404Z      info    builders/builders.go:26 Development component. May change in the future.        {"otelcol.component.id": "hostmetrics", "otelcol.component.kind": "Receiver", "otelcol.signal": "logs"}
otel | 2025-03-24T22:43:22.404Z      warn    filesystemscraper/factory.go:48 No `root_path` config set when running in docker environment, will report container filesystem stats. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#collecting-host-metrics-from-inside-a-container-linux-only {"otelcol.component.id": "hostmetrics", "otelcol.component.kind": "Receiver", "otelcol.signal": "metrics"}
otel | 2025-03-24T22:43:22.405Z      info    service@v0.122.1/service.go:260 Starting otelcol-contrib...     {"Version": "0.122.1", "NumCPU": 32}
otel | 2025-03-24T22:43:22.405Z      info    extensions/extensions.go:40     Starting extensions...
otel | 2025-03-24T22:43:22.406Z      info    otlpreceiver@v0.122.1/otlp.go:173       Starting HTTP server    {"otelcol.component.id": "otlp", "otelcol.component.kind": "Receiver", "endpoint": "0.0.0.0:4318"}
otel | 2025-03-24T22:43:22.406Z      info    service@v0.122.1/service.go:283 Everything is ready. Begin running and processing data.
```