### PR TITLE
Add missing `dependencies` arg to readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ job:
     package-manager: npm_and_yarn
     allowed-updates:
       - update-type: all
+    dependencies: # required arg when `security-updates-only: true` set
+      - 'express'
     security-advisories:
       - dependency-name: express
         affected-versions:
@@ -362,10 +364,9 @@ the issue, see <https://github.com/dependabot/cli/issues/113#issuecomment-161012
 
 ### `ensure_equivalent_gemfile_and_lockfile` error
 
-This error occurs when using `script/dependabot` and the Updater image is not in sync with dependabot-core. It can be resolved by rebuilding the Updater image. 
+This error occurs when using `script/dependabot` and the Updater image is not in sync with dependabot-core. It can be resolved by rebuilding the Updater image.
 
 For example, to rebuild the Updater image of the Go ecosystem, run this in the dependabot-core repository:
 ``` console
 $ script/build go_modules
 ```
-


### PR DESCRIPTION
Without this, I get the following error:
```shell
updater | 2025/04/01 22:28:59 ERROR Passed `nil` into T.must
updater | 2025/04/01 22:28:59 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11952/lib/types/_types.rb:222:in `must'
updater | 2025/04/01 22:28:59 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:87:in `block in allowed_dependencies'
updater | 2025/04/01 22:28:59 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:87:in `select'
updater | 2025/04/01 22:28:59 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_snapshot.rb:87:in `allowed_dependencies'
```

This is because in Dependabot-Core, security updates are required to explicitly pass in the desired `dependencies`:
https://github.com/dependabot/dependabot-core/blob/c8681bf6c474567f471128fbe37383706a22c647/updater/lib/dependabot/dependency_snapshot.rb#L86-L87