### PR TITLE
Generate build provenance for CLI releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,6 @@ jobs:
       - uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.3.3
         with:
           subject-path: |
-            "${{ steps.go_release.outputs.release_asset_dir }}/*"
-            "dependabot-${{ github.ref_name}}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz"
-            "dependabot-${{ github.ref_name}}-${{ matrix.goos }}-${{ matrix.goarch }}.zip"
+            ${{ steps.go_release.outputs.release_asset_dir }}/*
+            dependabot-${{ github.ref_name}}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
+            dependabot-${{ github.ref_name}}-${{ matrix.goos }}-${{ matrix.goarch }}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,9 @@ jobs:
     name: Release Go Binary
     runs-on: ubuntu-latest
     permissions:
+        attestations: write
         contents: write
+        id-token: write
         packages: write
     strategy:
       matrix:
@@ -24,6 +26,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: wangyoucao577/go-release-action@481a2c1a0f1be199722e3e9b74d7199acafc30a8 # v1.53
+        id: go_release
         with:
           goversion: go.mod
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -33,3 +36,10 @@ jobs:
           project_path: cmd/dependabot
           ldflags: >-
             -X github.com/dependabot/cli/cmd/dependabot/internal/cmd.version=${{ github.event.release.tag_name }}
+
+      - uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.3.3
+        with:
+          subject-path: |
+            "${{ steps.go_release.outputs.release_asset_dir }}/*"
+            "dependabot-${{ github.ref_name}}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz"
+            "dependabot-${{ github.ref_name}}-${{ matrix.goos }}-${{ matrix.goarch }}.zip"


### PR DESCRIPTION
Once this is merged, and a release is created, the CLI binary will be built with the necessary provenance. This will allow us to verify the authenticity of the binary and ensure that it was built from the correct source code. This is an important security feature that will help us maintain the integrity of our releases.

We can verify the provenance using: `gh attestation verify` command. For example `gh attestation verify dependabot --repo dependabot/cli`.