### PR TITLE
remove rsc/quote as the updater is failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Usage:
   dependabot [command]
 
 Examples:
-  $ dependabot update go_modules rsc/quote
+  $ dependabot update go_modules dependabot/cli
   $ dependabot test -f input.yml
 
 Available Commands:
@@ -63,7 +63,7 @@ Run the `update` subcommand to run a Dependabot update job for the provided ecos
 This does not create PRs, but outputs data that could be used to create PRs.
 
 ```console
-$ dependabot update go_modules rsc/quote
+$ dependabot update go_modules dependabot/cli
 # ...
 +----------------------------------------------------+
 |        Changes to Dependabot Pull Requests         |
@@ -269,7 +269,7 @@ To produce a scenario file that tests Dependabot behavior for a given repo,
 run the `update` subcommand and set the `--output` / `-o` option to a file path.
 
 ```console
-dependabot update go_modules rsc/quote -o go-scenario.yml
+dependabot update go_modules dependabot/cli -o go-scenario.yml
 ```
 
 Run the `test` subcommand for the generated scenario file,

--- a/cmd/dependabot/internal/cmd/root.go
+++ b/cmd/dependabot/internal/cmd/root.go
@@ -39,7 +39,7 @@ var rootCmd = &cobra.Command{
 	Short: "Dependabot end-to-end runner",
 	Long:  `Run Dependabot jobs from the command line.`,
 	Example: heredoc.Doc(`
-        $ dependabot update go_modules rsc/quote
+        $ dependabot update go_modules dependabot/cli
         $ dependabot test -f input.yml
 	`),
 	Version: Version(),

--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -54,7 +54,7 @@ func NewUpdateCommand() *cobra.Command {
 		Use:   "update [<package_manager> <repo> | -f <input.yml>] [flags]",
 		Short: "Perform an update job",
 		Example: heredoc.Doc(`
-		    $ dependabot update go_modules rsc/quote
+		    $ dependabot update go_modules dependabot/cli
 		    $ dependabot update -f input.yml
 	    `),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/dependabot/internal/cmd/update_test.go
+++ b/cmd/dependabot/internal/cmd/update_test.go
@@ -190,7 +190,7 @@ func assertStringArraysEqual(t *testing.T, expected, actual []string) {
 func Test_extractInput(t *testing.T) {
 	t.Run("test arguments", func(t *testing.T) {
 		cmd := NewUpdateCommand()
-		if err := cmd.ParseFlags([]string{"go_modules", "rsc/quote"}); err != nil {
+		if err := cmd.ParseFlags([]string{"go_modules", "dependabot/cli"}); err != nil {
 			t.Fatal(err)
 		}
 		input, err := extractInput(cmd, &UpdateFlags{})

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -4,11 +4,11 @@ This guide will help you debug issues with your Dependabot update using the Depe
 
 ## Getting started
 
-First, test to make sure you have a working Dependabot CLI by performing a simple update, like `dependabot update go_modules rsc/quote -o out.yml`. This should complete without error, and you can examine the out.yml file which should contain two calls to `create_pull_request`.
+First, test to make sure you have a working Dependabot CLI by performing a simple update, like `dependabot update go_modules dependabot/cli -o out.yml`. This should complete without error, and you can examine the out.yml file which should contain two calls to `create_pull_request`.
 
 Next, clone https://github.com/dependabot/dependabot-core. This project contains all the source for the updater images, and a helpful script `script/dependabot` which will mount the ecosystems in the container that the CLI starts.
 
-Try opening a terminal and run `script/dependabot update go_modules rsc/quote --debug` in the `dependabot-core` project directory. This will drop you in an interactive session with the update ready to proceed.
+Try opening a terminal and run `script/dependabot update go_modules dependabot/cli --debug` in the `dependabot-core` project directory. This will drop you in an interactive session with the update ready to proceed.
 
 To perform the update, you need to run two commands:
 

--- a/testdata/basic.yml
+++ b/testdata/basic.yml
@@ -5,5 +5,5 @@ job:
       update-type: all
   source:
     provider: github
-    repo: rsc/quote
+    repo: dependabot/cli
     directory: /

--- a/testdata/invalid-commit.yml
+++ b/testdata/invalid-commit.yml
@@ -5,6 +5,6 @@ job:
       update-type: all
   source:
     provider: github
-    repo: rsc/quote
+    repo: dependabot/cli
     directory: /
     commit: unknown

--- a/testdata/scenario.yml
+++ b/testdata/scenario.yml
@@ -6,5 +6,5 @@ input:
         update-type: all
     source:
       provider: github
-      repo: rsc/quote
+      repo: dependabot/cli
       directory: /

--- a/testdata/valid-commit.yml
+++ b/testdata/valid-commit.yml
@@ -5,6 +5,6 @@ job:
       update-type: all
   source:
     provider: github
-    repo: rsc/quote
+    repo: dependabot/cli
     directory: /
     commit: 5d9f230bcfbae514bb6c2215694c2ce7273fc604


### PR DESCRIPTION
- fixes #420 

`rsc/quote` is a bad example as the `go.mod` doesn't have a `go` directive.

So I've swapped that out for `dependabot/cli` which should be kept up to date.

We might also want to consider a friendlier message when trying to update an older Go project, but that would be a dependabot-core concern.