### PR TITLE
fixes Python cert error connecting to pypi.org

### DIFF
--- a/internal/infra/cadetails.go
+++ b/internal/infra/cadetails.go
@@ -63,6 +63,8 @@ func generateCert(key *rsa.PrivateKey) (string, error) {
 		Subject:               CertSubject,
 		NotBefore:             notBefore,
 		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageAny, x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		SignatureAlgorithm:    x509.SHA256WithRSA,
 		BasicConstraintsValid: true,
 		IsCA:                  true,

--- a/script/e2e
+++ b/script/e2e
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+if ! command -v go &> /dev/null
+then
+    echo "Go needs to be installed to run these tests"
+    exit
+fi
+
+if ! command -v dependabot &> /dev/null
+then
+    echo "Dependabot CLI needs to be installed to run these tests"
+    exit
+fi
+
+# If there's 1 argument, use it as a regex to match the test name.
+if [ $# -eq 1 ]
+then
+    # count=1 is used to prevent Go from caching test results.
+    # It can occasionally be confusing without this.
+    go test cmd/dependabot/dependabot_test.go -count=1 -test.run "/.*$1.*/"
+else
+    go test cmd/dependabot/dependabot_test.go -count=1
+fi

--- a/testdata/scripts/pypi.txt
+++ b/testdata/scripts/pypi.txt
@@ -1,0 +1,23 @@
+# this test verifies the certificate generated allows us to connect to pypi.org
+exec docker build -qt pypi-updater .
+
+dependabot update go_modules dependabot/cli --updater-image pypi-updater
+stderr '200 https://pypi.org:443/'
+
+exec docker rmi -f pypi-updater
+
+-- Dockerfile --
+FROM python:3.13-bookworm
+
+RUN apt-get update && apt-get install -y ca-certificates curl python3 python3-pip
+RUN python3 -m pip install --upgrade pip && python3 -m pip install requests
+RUN useradd dependabot && chgrp dependabot /etc/ssl/certs && chmod g+w /etc/ssl/certs
+ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
+COPY --chown=dependabot --chmod=755 run bin/run
+
+-- run --
+#!/usr/bin/env bash
+
+python3 --version
+python3 -c 'import requests; requests.get("https://pypi.org")'


### PR DESCRIPTION
This adds the necessary `KeyUsage` and `ExtKeyUsage` fields to the certificate generation function in `cadetails.go` to ensure that the generated certificate is compatible with Python 3.10.

I'm unsure what the exact requirements are but this seems to do the trick.

Trying to figure out if this is testable.

We will need to make the same change in dependabot-action.