### PR TITLE
fix unable to use CLI in corporate proxy setting

### DIFF
--- a/internal/infra/proxy.go
+++ b/internal/infra/proxy.go
@@ -79,6 +79,9 @@ func NewProxy(ctx context.Context, cli *client.Client, params *RunParams, nets *
 	config := &container.Config{
 		Image: params.ProxyImage,
 		Env: []string{
+			"HTTP_PROXY=" + os.Getenv("HTTP_PROXY"),
+			"HTTPS_PROXY=" + os.Getenv("HTTPS_PROXY"),
+			"NO_PROXY=" + os.Getenv("NO_PROXY"),
 			"JOB_ID=" + jobID,
 			"PROXY_CACHE=true",
 			"LOG_RESPONSE_BODY_ON_AUTH_FAILURE=true",


### PR DESCRIPTION
It's common in corporate settings to have a proxy setup which routes calls through a corporate proxy. The dependabot-action handles that [here](https://github.com/github/dependabot-action/blob/84109256d0b9433ef99206e3b7fadbe76622bc4c/src/proxy.ts#L229-L233), but the CLI didn't have these environment variables set yet. 

From a CLI perspective it makes sense to simply pass these along rather than make a dedicated flag for it as it should then "just work."

- fixes #450