### PR TITLE
Delete duplicate CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @dependabot/maintainers


### PR DESCRIPTION
There's a CODEOWNERS file at the root directory which wasn't working, and it's because GitHub prefers this location over the other. 

So we have to delete one or the other, I prefer the more visible one at the root, and we have a number of internal repos that also do that.