### PR TITLE
Run `update-ca-certificates` as `root`

### DIFF
--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/docker/docker/api/types/container"
 	"io"
 	"log"
 	"net/http"
@@ -16,6 +15,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/docker/docker/api/types/container"
 
 	"github.com/dependabot/cli/internal/model"
 	"github.com/dependabot/cli/internal/server"
@@ -423,11 +424,17 @@ func runContainers(ctx context.Context, params RunParams) (err error) {
 			return err
 		}
 	} else {
+		// First, update CA certificates as root
+		if err := updater.RunCmd(ctx, "update-ca-certificates", root); err != nil {
+			return err
+		}
+
+		// Then run the dependabot commands as the dependabot user
 		env := userEnv(prox.url, params.ApiUrl)
 		if params.Flamegraph {
 			env = append(env, "FLAMEGRAPH=1")
 		}
-		const cmd = "update-ca-certificates && bin/run fetch_files && bin/run update_files"
+		const cmd = "bin/run fetch_files && bin/run update_files"
 		if err := updater.RunCmd(ctx, cmd, dependabot, env...); err != nil {
 			return err
 		}


### PR DESCRIPTION
As part of https://github.com/dependabot/dependabot-core/pull/9627, I am seeing failures related to updating the CA certificates for Java when running as the `dependabot` user:

```
Updating certificates in /etc/ssl/certs...
rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
 1 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
/etc/ca-certificates/update.d/jks-keystore: 14: cannot create /var/lib/ca-certificates-java/pending: Permission denied
E: /etc/ca-certificates/update.d/jks-keystore exited with code 2.
done.
```

Even when granting those permissions, I start to see issue around permissions running `dpkg`. It looks like the ca-certificates hook that the `ca-certificates-java` package installs (`jks-keystore`) is significantly changed between Ubuntu 22.04 and 24.04:

<details>
<summary>Ubuntu 22.04</summary>

```sh
#!/bin/sh

set -e

# use the locale C.UTF-8
unset LC_ALL
LC_CTYPE=C.UTF-8
export LC_CTYPE

storepass='changeit'
if [ -f /etc/default/cacerts ]; then
    . /etc/default/cacerts
fi

arch=`dpkg --print-architecture`
JAR=/usr/share/ca-certificates-java/ca-certificates-java.jar

nsslib_name()
{
    if dpkg --assert-multi-arch 2>/dev/null; then
        echo "libnss3:${arch}"
    else
        echo "libnss3"
    fi
}

echo ""
if [ "$cacerts_updates" != yes ] || [ "$CACERT_UPDATES" = disabled ] || [ ! -e $JAR ]; then
    echo "updates of cacerts keystore disabled."
    exit 0
fi

if ! mountpoint -q /proc; then
    echo >&2 "the keytool command requires a mounted proc fs (/proc)."
    exit 1
fi

for jvm in java-7-openjdk-$arch java-7-openjdk \
           oracle-java7-jre-$arch oracle-java7-server-jre-$arch oracle-java7-jdk-$arch \
           java-8-openjdk-$arch java-8-openjdk \
           oracle-java8-jre-$arch oracle-java8-server-jre-$arch oracle-java8-jdk-$arch \
           java-9-openjdk-$arch java-9-openjdk \
           oracle-java9-jre-$arch oracle-java9-server-jre-$arch oracle-java9-jdk-$arch \
           java-10-openjdk-$arch java-10-openjdk \
           oracle-java10-jre-$arch oracle-java10-server-jre-$arch oracle-java10-jdk-$arch \
           java-11-openjdk-$arch java-11-openjdk \
           oracle-java11-jre-$arch oracle-java11-server-jre-$arch oracle-java11-jdk-$arch; do
    if [ -x /usr/lib/jvm/$jvm/bin/java ]; then
        export JAVA_HOME=/usr/lib/jvm/$jvm
        PATH=$JAVA_HOME/bin:$PATH
    	break
    fi
done

if dpkg-query --version >/dev/null; then
    nsspkg=$(dpkg-query -L "$(nsslib_name)" | sed -n 's,\(.*\)/libnss3\.so$,\1,p'|head -n 1)
    nsscfg=/etc/${jvm%-$arch}/security/nss.cfg
    nssjdk=$(test ! -f $nsscfg || sed -n '/nssLibraryDirectory/s/.*= *\(.*\)/\1/p' $nsscfg)
    if [ -n "$nsspkg" ] && [ -n "$nssjdk" ] && [ "$nsspkg" != "$nssjdk" ]; then
        ln -sf $nsspkg/libnss3.so $nssjdk/libnss3.so
    fi
    softokn3pkg=$(dpkg-query -L "$(nsslib_name)" | sed -n 's,\(.*\)/libsoftokn3\.so$,\1,p'|head -n 1)
    if [ -n "$softokn3pkg" ] && [ -n "$nssjdk" ] && [ "$softokn3pkg" != "$nssjdk" ]; then
        ln -sf $softokn3pkg/libsoftokn3.so $nssjdk/libsoftokn3.so
    fi
fi

do_cleanup()
{
    [ -z "$temp_jvm_cfg" ] || rm -f $temp_jvm_cfg
    if [ -n "$nsspkg" ] && [ -n "$nssjdk" ] && [ "$nsspkg" != "$nssjdk" ]
    then
        rm -f $nssjdk/libnss3.so
    fi
    if [ -n "$softokn3pkg" ] && [ -n "$nssjdk" ] \
       && [ "$softokn3pkg" != "$nssjdk" ]
    then
        rm -f $nssjdk/libsoftokn3.so
    fi
}

if java -Xmx64m -jar $JAR -storepass "$storepass"; then
    do_cleanup
else
    do_cleanup
    exit 1
fi

echo "done."
```

</details>

<details>
<summary>Ubuntu 24.04</summary>

```sh
#!/bin/sh
set -e

if [ -t 0 ]; then
	echo "This hook script expects the list of PEM files to be added/removed" >&2
	echo "prefixed with '+'/'-' to be piped into stdin." >&2
	exit 1
fi

# record the pending certificate updates for later execution by the
# triggers in ca-certificates-java

mkdir -p /var/lib/ca-certificates-java
cat - >> /var/lib/ca-certificates-java/pending

case "$1" in
	*)
		dpkg-trigger --no-await update-ca-certificates-java
		;;
esac

# if the hook was activated by a manual run of update-ca-certificates
# (and not from a maintainer script), ensure the triggers get processed

if [ -z "$DPKG_MAINTSCRIPT_PACKAGE" ]; then
	dpkg --triggers-only --pending
fi
```

</details>

I'm not sure that it's possible to run `dpkg` as a non-superuser. So this change runs `update-ca-certificates` as `root` separately to running the rest of the Dependabot commands.