### PR TITLE
simplify by putting the cert directly into the Updater's CA bundle

### DIFF
--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -428,7 +428,7 @@ func runContainers(ctx context.Context, params RunParams) (err error) {
 		if params.Flamegraph {
 			env = append(env, "FLAMEGRAPH=1")
 		}
-		const cmd = "update-ca-certificates && bin/run fetch_files && bin/run update_files"
+		const cmd = "bin/run fetch_files && bin/run update_files"
 		if err := updater.RunCmd(ctx, cmd, dependabot, env...); err != nil {
 			return err
 		}

--- a/internal/infra/updater.go
+++ b/internal/infra/updater.go
@@ -42,10 +42,7 @@ type Updater struct {
 	ExitCode *int
 }
 
-const (
-	certsPath = "/etc/ssl/certs"
-	dbotCert  = "/usr/local/share/ca-certificates/dbot-ca.crt"
-)
+const dbotCert = "/etc/ssl/certs/ca-certificates.crt"
 
 // NewUpdater starts the update container interactively running /bin/sh, so it does not stop.
 func NewUpdater(ctx context.Context, cli *client.Client, net *Networks, params *RunParams, prox *Proxy, collector *Collector) (*Updater, error) {
@@ -168,7 +165,7 @@ func userEnv(proxyURL string, apiUrl string) []string {
 		fmt.Sprintf("DEPENDABOT_OUTPUT_PATH=%v", guestOutput),
 		fmt.Sprintf("DEPENDABOT_REPO_CONTENTS_PATH=%v", guestRepoDir),
 		fmt.Sprintf("DEPENDABOT_API_URL=%s", apiUrl),
-		fmt.Sprintf("SSL_CERT_FILE=%v/ca-certificates.crt", certsPath),
+		fmt.Sprintf("SSL_CERT_FILE=%v", dbotCert),
 		"UPDATER_ONE_CONTAINER=true",
 		"UPDATER_DETERMINISTIC=true",
 	}
@@ -183,7 +180,7 @@ func (u *Updater) RunShell(ctx context.Context, proxyURL string, apiUrl string) 
 		Tty:          true,
 		User:         dependabot,
 		Env:          append(userEnv(proxyURL, apiUrl), "DEBUG=1"),
-		Cmd:          []string{"/bin/bash", "-c", "update-ca-certificates && /bin/bash"},
+		Cmd:          []string{"/bin/bash"},
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create exec: %w", err)

--- a/testdata/scripts/basic.txt
+++ b/testdata/scripts/basic.txt
@@ -15,13 +15,7 @@ FROM ubuntu:22.04
 
 RUN useradd dependabot
 
-COPY --chown=dependabot --chmod=755 update-ca-certificates /usr/bin/update-ca-certificates
 COPY --chown=dependabot --chmod=755 run bin/run
-
--- update-ca-certificates --
-#!/usr/bin/env bash
-
-echo "Updated those certificates for ya"
 
 -- run --
 #!/usr/bin/env bash

--- a/testdata/scripts/credentials.txt
+++ b/testdata/scripts/credentials.txt
@@ -87,13 +87,7 @@ FROM ubuntu:22.04
 
 RUN useradd dependabot
 
-COPY --chown=dependabot --chmod=755 update-ca-certificates /usr/bin/update-ca-certificates
 COPY --chown=dependabot --chmod=755 run bin/run
-
--- update-ca-certificates --
-#!/usr/bin/env bash
-
-echo "Updated those certificates for ya"
 
 -- run --
 #!/usr/bin/env bash

--- a/testdata/scripts/fail.txt
+++ b/testdata/scripts/fail.txt
@@ -13,13 +13,7 @@ FROM ubuntu:22.04
 
 RUN useradd dependabot
 
-COPY --chown=dependabot --chmod=755 update-ca-certificates /usr/bin/update-ca-certificates
 COPY --chown=dependabot --chmod=755 run bin/run
-
--- update-ca-certificates --
-#!/usr/bin/env bash
-
-echo "Updating CA certificates..."
 
 -- run --
 #!/usr/bin/env bash

--- a/testdata/scripts/flamegraph.txt
+++ b/testdata/scripts/flamegraph.txt
@@ -14,13 +14,7 @@ FROM ubuntu:22.04
 
 RUN useradd dependabot
 
-COPY --chown=dependabot --chmod=755 update-ca-certificates /usr/bin/update-ca-certificates
 COPY --chown=dependabot --chmod=755 run bin/run
-
--- update-ca-certificates --
-#!/usr/bin/env bash
-
-echo "Updated those certificates for ya"
 
 -- run --
 #!/usr/bin/env bash

--- a/testdata/scripts/input.txt
+++ b/testdata/scripts/input.txt
@@ -28,13 +28,7 @@ FROM ubuntu:22.04
 
 RUN useradd dependabot
 
-COPY --chown=dependabot --chmod=755 update-ca-certificates /usr/bin/update-ca-certificates
 COPY --chown=dependabot --chmod=755 run bin/run
-
--- update-ca-certificates --
-#!/usr/bin/env bash
-
-echo "Updated those certificates for ya"
 
 -- run --
 #!/usr/bin/env bash

--- a/testdata/scripts/proxy.txt
+++ b/testdata/scripts/proxy.txt
@@ -40,7 +40,6 @@ FROM ubuntu:22.04
 
 RUN useradd dependabot
 
-COPY --chown=dependabot --chmod=755 update-ca-certificates /usr/bin/update-ca-certificates
 COPY --chown=dependabot --chmod=755 run bin/run
 
 -- update-ca-certificates --

--- a/testdata/scripts/timeout.txt
+++ b/testdata/scripts/timeout.txt
@@ -10,13 +10,7 @@ FROM ubuntu:22.04
 
 RUN useradd dependabot
 
-COPY --chown=dependabot --chmod=755 update-ca-certificates /usr/bin/update-ca-certificates
 COPY --chown=dependabot --chmod=755 run bin/run
-
--- update-ca-certificates --
-#!/usr/bin/env bash
-
-echo "Updated those certificates for ya"
 
 -- run --
 #!/usr/bin/env bash


### PR DESCRIPTION
I had been meaning to try this. By putting the Proxy cert directly into the system's trusted CA bundle, we can avoid needing to run `update-ca-certificates`. This only works because the Updater can only communicate via the Proxy, so all other certs are not needed.