### PR TITLE
use smb volume for case insensitive jobs

### DIFF
--- a/cmd/dependabot/internal/cmd/root.go
+++ b/cmd/dependabot/internal/cmd/root.go
@@ -31,6 +31,7 @@ var (
 	updaterImage   string
 	proxyImage     string
 	collectorImage string
+	storageImage   string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -59,4 +60,5 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&updaterImage, "updater-image", "", "container image to use for the updater")
 	rootCmd.PersistentFlags().StringVar(&proxyImage, "proxy-image", infra.ProxyImageName, "container image to use for the proxy")
 	rootCmd.PersistentFlags().StringVar(&collectorImage, "collector-image", infra.CollectorImageName, "container image to use for the OpenTelemetry collector")
+	rootCmd.PersistentFlags().StringVar(&storageImage, "storage-image", infra.StorageImageName, "container image to use for the storage service")
 }

--- a/cmd/dependabot/internal/cmd/test.go
+++ b/cmd/dependabot/internal/cmd/test.go
@@ -50,6 +50,7 @@ func NewTestCommand() *cobra.Command {
 				ProxyCertPath:       flags.proxyCertPath,
 				ProxyImage:          proxyImage,
 				PullImages:          flags.pullImages,
+				StorageImage:        storageImage,
 				Timeout:             flags.timeout,
 				UpdaterImage:        updaterImage,
 				Volumes:             flags.volumes,

--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -96,6 +96,7 @@ func NewUpdateCommand() *cobra.Command {
 				ProxyCertPath:       flags.proxyCertPath,
 				ProxyImage:          proxyImage,
 				PullImages:          flags.pullImages,
+				StorageImage:        storageImage,
 				Timeout:             flags.timeout,
 				UpdaterImage:        updaterImage,
 				Volumes:             flags.volumes,

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -427,6 +427,7 @@ func runContainers(ctx context.Context, params RunParams) (err error) {
 	if params.LocalDir != "" {
 		containerDir := guestRepoDir
 		if params.Job.UseCaseInsensitiveFileSystem() {
+			// since the updater is using the storage container, we need to populate the repo on that device because that's the directory that will be used for the update
 			containerDir = caseSensitiveRepoContentsPath
 		}
 		if err = putCloneDir(ctx, cli, updater, params.LocalDir, containerDir); err != nil {

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -68,6 +68,8 @@ type RunParams struct {
 	CollectorImage string
 	// CollectorConfigPath is the path to the OpenTelemetry collector configuration file
 	CollectorConfigPath string
+	// StorageImage is the image to use for the storage service
+	StorageImage string
 	// Writer is where API calls will be written to
 	Writer    io.Writer
 	InputName string
@@ -368,6 +370,13 @@ func runContainers(ctx context.Context, params RunParams) (err error) {
 		err = pullImage(ctx, cli, params.UpdaterImage)
 		if err != nil {
 			return err
+		}
+
+		if params.Job.UseCaseInsensitiveFileSystem() {
+			err = pullImage(ctx, cli, params.StorageImage)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -416,13 +416,17 @@ func runContainers(ctx context.Context, params RunParams) (err error) {
 
 	// put the clone dir in the updater container to be used by during the update
 	if params.LocalDir != "" {
-		if err = putCloneDir(ctx, cli, updater, params.LocalDir); err != nil {
+		containerDir := guestRepoDir
+		if params.Job.UseCaseInsensitiveFileSystem() {
+			containerDir = caseSensitiveRepoContentsPath
+		}
+		if err = putCloneDir(ctx, cli, updater, params.LocalDir, containerDir); err != nil {
 			return err
 		}
 	}
 
 	if params.Debug {
-		if err := updater.RunShell(ctx, prox.url, params.ApiUrl); err != nil {
+		if err := updater.RunShell(ctx, prox.url, params.ApiUrl, params.Job); err != nil {
 			return err
 		}
 	} else {
@@ -432,7 +436,7 @@ func runContainers(ctx context.Context, params RunParams) (err error) {
 		}
 
 		// Then run the dependabot commands as the dependabot user
-		env := userEnv(prox.url, params.ApiUrl)
+		env := userEnv(prox.url, params.ApiUrl, params.Job)
 		if params.Flamegraph {
 			env = append(env, "FLAMEGRAPH=1")
 		}
@@ -473,33 +477,33 @@ func getFromContainer(ctx context.Context, cli *client.Client, containerID, srcP
 	}
 }
 
-func putCloneDir(ctx context.Context, cli *client.Client, updater *Updater, dir string) error {
+func putCloneDir(ctx context.Context, cli *client.Client, updater *Updater, localDir, containerDir string) error {
 	// Docker won't create the directory, so we have to do it first.
-	const cmd = "mkdir -p " + guestRepoDir
+	cmd := fmt.Sprintf("mkdir -p %s", containerDir)
 	err := updater.RunCmd(ctx, cmd, dependabot)
 	if err != nil {
 		return fmt.Errorf("failed to create clone dir: %w", err)
 	}
 
-	r, err := archive.TarWithOptions(dir, &archive.TarOptions{})
+	r, err := archive.TarWithOptions(localDir, &archive.TarOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to tar clone dir: %w", err)
 	}
 
 	opt := container.CopyToContainerOptions{}
-	err = cli.CopyToContainer(ctx, updater.containerID, guestRepoDir, r, opt)
+	err = cli.CopyToContainer(ctx, updater.containerID, containerDir, r, opt)
 	if err != nil {
 		return fmt.Errorf("failed to copy clone dir to container: %w", err)
 	}
 
-	err = updater.RunCmd(ctx, "chown -R dependabot "+guestRepoDir, root)
+	err = updater.RunCmd(ctx, "chown -R dependabot "+containerDir, root)
 	if err != nil {
 		return fmt.Errorf("failed to initialize clone dir: %w", err)
 	}
 
 	// The directory needs to be a git repo, so we need to initialize it.
 	commands := []string{
-		"cd " + guestRepoDir,
+		"cd " + containerDir,
 		"git config --global init.defaultBranch main",
 		"git init",
 		"git config user.email 'dependabot@github.com'",

--- a/internal/infra/updater.go
+++ b/internal/infra/updater.go
@@ -43,7 +43,7 @@ const (
 	caseInsensitiveContainerRoot    = "/nocase"
 	caseInsensitiveRepoContentsPath = "/nocase/repo"
 
-	storageImageName = "ghcr.io/dependabot/dependabot-storage"
+	StorageImageName = "ghcr.io/dependabot/dependabot-storage"
 	storageUser      = "dpduser"
 	storagePass      = "dpdpass"
 )
@@ -102,7 +102,7 @@ func NewUpdater(ctx context.Context, cli *client.Client, net *Networks, params *
 	storageContainerID := ""
 	storageVolumes := []string{}
 	if params.Job.UseCaseInsensitiveFileSystem() {
-		storageContainerID, storageVolumes, err = createStorageVolumes(hostCfg, ctx, cli, net)
+		storageContainerID, storageVolumes, err = createStorageVolumes(hostCfg, ctx, cli, net, params.StorageImage)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create storage volumes: %w", err)
 		}
@@ -141,7 +141,7 @@ func NewUpdater(ctx context.Context, cli *client.Client, net *Networks, params *
 	return updater, nil
 }
 
-func createStorageVolumes(hostCfg *container.HostConfig, ctx context.Context, cli *client.Client, net *Networks) (storageContainerID string, volumeNames []string, err error) {
+func createStorageVolumes(hostCfg *container.HostConfig, ctx context.Context, cli *client.Client, net *Networks, storageImageName string) (storageContainerID string, volumeNames []string, err error) {
 	log.Printf("Preparing case insensitive filesystem")
 
 	// create container hosting the storage

--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -54,6 +54,14 @@ type Job struct {
 	UpdateCooldown             *UpdateCooldown   `json:"cooldown,omitempty" yaml:"cooldown,omitempty"`
 }
 
+func (j *Job) UseCaseInsensitiveFileSystem() bool {
+	if experimentValue, isBoolean := j.Experiments["use_case_insensitive_filesystem"].(bool); isBoolean && experimentValue {
+		return true
+	}
+
+	return false
+}
+
 // Source is a reference to some source code
 type Source struct {
 	Provider    string   `json:"provider" yaml:"provider,omitempty"`

--- a/testdata/scripts/smb-mount.txt
+++ b/testdata/scripts/smb-mount.txt
@@ -1,0 +1,49 @@
+# Build the dummy Dockerfile
+exec docker build -qt dummy-nocase-updater .
+
+# Run the dependabot command
+dependabot update -f job.yml --updater-image dummy-nocase-updater
+
+# assert the dummy is working
+stderr 'case-insensitive storage is working'
+
+exec docker rmi -f dummy-nocase-updater
+
+-- Dockerfile --
+FROM ubuntu:22.04
+
+RUN useradd dependabot
+
+COPY --chown=dependabot --chmod=755 update-ca-certificates /usr/bin/update-ca-certificates
+COPY --chown=dependabot --chmod=755 run bin/run
+
+-- update-ca-certificates --
+#!/usr/bin/env bash
+
+echo "Updated those certificates for ya"
+
+-- run --
+#!/usr/bin/env bash
+
+if [ "$1" = "fetch_files" ]; then
+  # git clone would have created this directory
+  mkdir -p "$DEPENDABOT_REPO_CONTENTS_PATH"
+  exit 0
+fi
+
+echo "test file" > "$DEPENDABOT_REPO_CONTENTS_PATH/test.txt"
+if [ -e "$DEPENDABOT_CASE_INSENSITIVE_REPO_CONTENTS_PATH/TEST.TXT" ]; then
+  echo "case-insensitive storage is working"
+else
+  echo "case-insensitive storage is not working"
+fi
+
+-- job.yml --
+job:
+  experiments:
+    use_case_insensitive_filesystem: true
+  source:
+    provider: github
+    repo: test/repo
+    directory: /
+  package-manager: nuget


### PR DESCRIPTION
## Problem

More mature .NET repos with NuGet packages are commonly only built on Windows with a case-insensitive filesystem.  This can cause issues with the dependabot updater if there is a mismatch between the files in the repo and their casing in import statements.  Consider a `.csproj` with a line like `<Import Project="build/versions.props" />` but in the repo and on disk the file is named `build/Versions.props` (notice the upper-case `V`).  Since dependabot runs in a Linux host, all operations will fail because the requested files could not be loaded.  This same issue can arise if a NuGet package consumed by a repo has package-internal `<Import>` elements that don't match the casing of the file in the package.  All of these scenarios have been encountered.

## The Fix

To address this, dependabot needs to run on a case-insensitive filesystem, but that would add certain requirements for the Docker host that's running the update job.  To avoid this, we can use some functionality built into Docker itself, namely its ability to natively mount SMB/CIFS shares for use as volumes to bind to another container.  The SMB/CIFS sharing protocol was picked because it has an optional `nocase` mount option that makes all operations case-insensitive.

To accomplish this, the Docker host needs access to a SMB/CIFS share, but to again not impose additional requirements on the Docker host, a separate image is used, `ghcr.io.dependabot/dependabot-storage`.  That container only hosts a SMB/CIFS share on the default ports with a hardcoded username and password.  The default Docker configuration doesn't allow guest access so user/pass had to be used isntead.

## The changes to this codebase

Immediately before the updater container is created (e.g., from the `dependabot-updater-nuget` image), a new container is created from the `dependabot-storage` image and it is given no external internet access.  The host (this code) then mounts the SMB/CIFS share twice.  The first mount is with the standard options which is then given to the updater in the environment variable `$DEPENDABOT_REPO_CONTENTS_PATH`.  The second mount is exactly the same as the first, except with the `nocase` option and it is exposed to the updater in the environment variable `$DEPENDABOT_CASE_INSENSITIVE_REPO_CONTENTS_PATH`.

The job the proceeds as normal and the container cleanup operations have been amended to also remove the storage container and both volume mounts.

All of this work is behind a new feature flag `use_case_insensitive_filesystem`.

This experiment is not expected to be enabled for non-NuGet jobs, but I've done some testing anyway and found no change in behavior because the updater reads its version of `$DEPENDABOT_REPO_CONTENTS_PATH` and proceeds as normal.  Nothing is done with the `..._CASE_INSENSITIVE_...` variable.

The changes here will also require a change to `dependabot/dependabot-core` (PR pending) where the updater is aware of both directory paths.  It performs all update work against the case-insensitive one then normalizes all file paths (e.g. the contents of `create_pull_request`) using the case-sensitive one.