### PR TITLE
Add exclude paths attribute to job definition

### DIFF
--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -52,6 +52,7 @@ type Job struct {
 	CredentialsMetadata        []Credential      `json:"credentials-metadata" yaml:"-"`
 	MaxUpdaterRunTime          int               `json:"max-updater-run-time" yaml:"max-updater-run-time,omitempty"`
 	UpdateCooldown             *UpdateCooldown   `json:"cooldown,omitempty" yaml:"cooldown,omitempty"`
+	ExcludePaths               []string          `json:"exclude-paths" yaml:"exclude-paths,omitempty"`
 }
 
 func (j *Job) UseCaseInsensitiveFileSystem() bool {

--- a/internal/model/job_test.go
+++ b/internal/model/job_test.go
@@ -369,4 +369,8 @@ job:
     exclude:
       - dependency-name-3
       - dependency-name-4
+  exclude-paths:
+    - "docs/"
+    - "examples/"
+    - "test/"
 `


### PR DESCRIPTION
This PR adds the `exclude-paths` option in dependabot-cli job config. This options allows the user to specify paths to manifest files in sub-directories which should be ignored during Dependabot updates.
Related epic - https://github.com/dependabot/dependabot-core/issues/4364