### PR TITLE
fix graph command not working without experiment enabled

### DIFF
--- a/cmd/dependabot/internal/cmd/graph.go
+++ b/cmd/dependabot/internal/cmd/graph.go
@@ -7,17 +7,11 @@ import (
 	"io"
 	"log"
 	"os"
-	"slices"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/dependabot/cli/internal/infra"
 	"github.com/spf13/cobra"
 )
-
-var graphSupportedEcosystems = []string{
-	"bundler",
-	"go_modules",
-}
 
 var graphCmd = NewGraphCommand()
 
@@ -59,13 +53,12 @@ func NewGraphCommand() *cobra.Command {
 
 			processInput(input, &flags)
 
-			if !slices.Contains(graphSupportedEcosystems, input.Job.PackageManager) {
-				return fmt.Errorf(
-					"package manager '%s' is not supported for graphing. Supported ecosystems: %v",
-					input.Job.PackageManager,
-					graphSupportedEcosystems,
-				)
+			// It doesn't make sense to suppress the graph output when running the graph command,
+			// so forcing the experiment to true.
+			if input.Job.Experiments == nil {
+				input.Job.Experiments = make(map[string]any)
 			}
+			input.Job.Experiments["enable_dependency_submission_poc"] = true
 
 			var writer io.Writer
 			if !flags.debugging {

--- a/testdata/scripts/graph.txt
+++ b/testdata/scripts/graph.txt
@@ -7,7 +7,7 @@ dependabot graph go_modules dependabot/cli --updater-image graph-updater
 # assert the dummy is working
 stderr 'bin/run arguments: fetch_files'
 stderr 'bin/run arguments: update_graph'
-stderr '"enable_dependency_submission_poc": true'
+stderr '"enable_dependency_submission_poc":true'
 
 exec docker rmi -f graph-updater
 

--- a/testdata/scripts/graph.txt
+++ b/testdata/scripts/graph.txt
@@ -1,0 +1,31 @@
+# Build the dummy Dockerfile
+exec docker build -qt graph-updater .
+
+# Run the dependabot command
+dependabot graph go_modules dependabot/cli --updater-image graph-updater
+
+# assert the dummy is working
+stderr 'bin/run arguments: fetch_files'
+stderr 'bin/run arguments: update_graph'
+stderr '"enable_dependency_submission_poc": true'
+
+exec docker rmi -f graph-updater
+
+-- Dockerfile --
+FROM ubuntu:22.04
+
+RUN useradd dependabot
+
+COPY --chown=dependabot --chmod=755 update-ca-certificates /usr/bin/update-ca-certificates
+COPY --chown=dependabot --chmod=755 run bin/run
+
+-- update-ca-certificates --
+#!/usr/bin/env bash
+
+echo "Updated those certificates for ya"
+
+-- run --
+#!/usr/bin/env bash
+
+echo "bin/run arguments: $@"
+cat /home/dependabot/dependabot-updater/job.json; echo


### PR DESCRIPTION
With this change we can now see the jsonl output in stdout from this command:

```
dependabot graph go_modules dependabot/cli 2>/dev/null
```

Although it's a bit nicer to read if you use the -o flag to generate a smoke test:

```
dependabot graph go_modules dependabot/cli -o out.yml
```

I also removed the restriction in ecosystems. It's an experiment so if it doesn't work then it doesn't work 😄 