### PR TITLE
Run update-ca-certificates also when debug flag is present

### DIFF
--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -451,17 +451,17 @@ func runContainers(ctx context.Context, params RunParams) (err error) {
 		}
 	}
 
+	// update CA certificates as root prior to start debug shell or running dependabot commands
+	if err := updater.RunCmd(ctx, "update-ca-certificates", root); err != nil {
+		return err
+	}
+
 	if params.Debug {
 		if err := updater.RunShell(ctx, prox.url, params.ApiUrl, params.Job, params.UpdaterEnvironmentVariables); err != nil {
 			return err
 		}
 	} else {
-		// First, update CA certificates as root
-		if err := updater.RunCmd(ctx, "update-ca-certificates", root); err != nil {
-			return err
-		}
-
-		// Then run the dependabot commands as the dependabot user
+		// Run dependabot commands as a dependabot user
 		env := userEnv(prox.url, params.ApiUrl, params.Job, params.UpdaterEnvironmentVariables)
 		if params.Flamegraph {
 			env = append(env, "FLAMEGRAPH=1")

--- a/internal/infra/updater.go
+++ b/internal/infra/updater.go
@@ -343,7 +343,7 @@ func (u *Updater) RunShell(ctx context.Context, proxyURL string, apiUrl string, 
 		Tty:          true,
 		User:         dependabot,
 		Env:          append(userEnv(proxyURL, apiUrl, job, additionalEnvVars), "DEBUG=1"),
-		Cmd:          []string{"/bin/bash", "-c", "update-ca-certificates && /bin/bash"},
+		Cmd:          []string{"/bin/bash"},
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create exec: %w", err)


### PR DESCRIPTION
Amendment to #466 to perform CA certificate update even if debug flag is provided. This solves the issue where some requests are failing during debugging.