### PR TITLE
add plumbing for graph smoke tests

### DIFF
--- a/cmd/dependabot/internal/cmd/graph.go
+++ b/cmd/dependabot/internal/cmd/graph.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/dependabot/cli/internal/infra"
+	"github.com/dependabot/cli/internal/model"
 	"github.com/spf13/cobra"
 )
 
@@ -66,7 +67,7 @@ func NewGraphCommand() *cobra.Command {
 			}
 
 			if err := infra.Run(infra.RunParams{
-				Command:             infra.UpdateGraphCommand,
+				Command:             model.UpdateGraphCommand,
 				CacheDir:            flags.cache,
 				CollectorConfigPath: flags.collectorConfigPath,
 				CollectorImage:      collectorImage,

--- a/cmd/dependabot/internal/cmd/graph.go
+++ b/cmd/dependabot/internal/cmd/graph.go
@@ -7,17 +7,11 @@ import (
 	"io"
 	"log"
 	"os"
-	"slices"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/dependabot/cli/internal/infra"
 	"github.com/spf13/cobra"
 )
-
-var graphSupportedEcosystems = []string{
-	"bundler",
-	"go_modules",
-}
 
 var graphCmd = NewGraphCommand()
 
@@ -59,13 +53,12 @@ func NewGraphCommand() *cobra.Command {
 
 			processInput(input, &flags)
 
-			if !slices.Contains(graphSupportedEcosystems, input.Job.PackageManager) {
-				return fmt.Errorf(
-					"package manager '%s' is not supported for graphing. Supported ecosystems: %v",
-					input.Job.PackageManager,
-					graphSupportedEcosystems,
-				)
+			// It doesn't make sense to suppress the graph output when running the graph command,
+			// so forcing the experiment to true.
+			if input.Job.Experiments == nil {
+				input.Job.Experiments = make(map[string]any)
 			}
+			input.Job.Experiments["enable_dependency_submission_poc"] = true
 
 			var writer io.Writer
 			if !flags.debugging {

--- a/cmd/dependabot/internal/cmd/test.go
+++ b/cmd/dependabot/internal/cmd/test.go
@@ -35,6 +35,7 @@ func NewTestCommand() *cobra.Command {
 			processInput(&smokeTest.Input, nil)
 
 			if err := executeTestJob(infra.RunParams{
+				Command:             smokeTest.Command,
 				CacheDir:            flags.cache,
 				CollectorConfigPath: flags.collectorConfigPath,
 				CollectorImage:      collectorImage,

--- a/internal/model/smoke.go
+++ b/internal/model/smoke.go
@@ -1,7 +1,16 @@
 package model
 
+type RunCommand string
+
+const (
+	UpdateFilesCommand RunCommand = "update"
+	UpdateGraphCommand RunCommand = "graph"
+)
+
 // SmokeTest is a way to test a job by asserting the outputs.
 type SmokeTest struct {
+	// Command is the command to run for testing a smoke test (update, graph)
+	Command RunCommand `yaml:"command"`
 	// Input is the input parameters
 	Input Input `yaml:"input"`
 	// Output is the list of expected outputs

--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -35,7 +35,6 @@ type DependencySubmissionRequest struct {
 	Ref       string         `json:"ref" yaml:"ref"`
 	Job       map[string]any `json:"job" yaml:"job"`
 	Detector  map[string]any `json:"detector" yaml:"detector"`
-	Scanned   string         `json:"scanned" yaml:"scanned"`
 	Manifests map[string]any `json:"manifests" yaml:"manifests"`
 }
 

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -282,13 +282,13 @@ func decode[T any](data []byte) (T, error) {
 	return wrapper.Data, nil
 }
 
-// TODO(brrygrdn): Add model.DependencySubmissionRequest to support smoke tests
-//
 // The test command only expects to run with `update` operations right now so
 // we will need to incorporate which run command is expected as well, but we
 // don't need regression coverage yet.
 func compare(expect, actual *model.UpdateWrapper) error {
 	switch v := expect.Data.(type) {
+	case model.DependencySubmissionRequest:
+		return compareDependencySubmissionRequest(v, actual.Data.(model.DependencySubmissionRequest))
 	case model.UpdateDependencyList:
 		return compareUpdateDependencyList(v, actual.Data.(model.UpdateDependencyList))
 	case model.CreatePullRequest:
@@ -312,6 +312,13 @@ func compare(expect, actual *model.UpdateWrapper) error {
 
 func unexpectedBody(kind string) error {
 	return fmt.Errorf("unexpected body for %s", kind)
+}
+
+func compareDependencySubmissionRequest(expect, actual model.DependencySubmissionRequest) error {
+	if reflect.DeepEqual(expect, actual) {
+		return nil
+	}
+	return unexpectedBody("dependency_submission_request")
 }
 
 func compareUpdateDependencyList(expect, actual model.UpdateDependencyList) error {

--- a/testdata/scripts/graph.txt
+++ b/testdata/scripts/graph.txt
@@ -7,7 +7,7 @@ dependabot graph go_modules dependabot/cli --updater-image graph-updater
 # assert the dummy is working
 stderr 'bin/run arguments: fetch_files'
 stderr 'bin/run arguments: update_graph'
-stderr '"enable_dependency_submission_poc": true'
+stderr '"enable_dependency_submission_poc":true'
 
 exec docker rmi -f graph-updater
 

--- a/testdata/scripts/graph.txt
+++ b/testdata/scripts/graph.txt
@@ -1,0 +1,31 @@
+# Build the dummy Dockerfile
+exec docker build -qt graph-updater .
+
+# Run the dependabot command
+dependabot graph go_modules dependabot/cli --updater-image graph-updater
+
+# assert the dummy is working
+stderr 'bin/run arguments: fetch_files'
+stderr 'bin/run arguments: update_graph'
+stderr '"enable_dependency_submission_poc": true'
+
+exec docker rmi -f graph-updater
+
+-- Dockerfile --
+FROM ubuntu:22.04
+
+RUN useradd dependabot
+
+COPY --chown=dependabot --chmod=755 update-ca-certificates /usr/bin/update-ca-certificates
+COPY --chown=dependabot --chmod=755 run bin/run
+
+-- update-ca-certificates --
+#!/usr/bin/env bash
+
+echo "Updated those certificates for ya"
+
+-- run --
+#!/usr/bin/env bash
+
+echo "bin/run arguments: $@"
+cat /home/dependabot/dependabot-updater/job.json; echo

--- a/testdata/scripts/graph.txt
+++ b/testdata/scripts/graph.txt
@@ -1,13 +1,19 @@
 # Build the dummy Dockerfile
 exec docker build -qt graph-updater .
 
-# Run the dependabot command
-dependabot graph go_modules dependabot/cli --updater-image graph-updater
+# Run the graph command and create a smoke test
+dependabot graph go_modules dependabot/cli -o out.yml --updater-image graph-updater
 
 # assert the dummy is working
 stderr 'bin/run arguments: fetch_files'
 stderr 'bin/run arguments: update_graph'
 stderr '"enable_dependency_submission_poc":true'
+
+# Verify the smoke test can run the graph command
+dependabot test -f out.yml --updater-image graph-updater
+
+stderr 'bin/run arguments: fetch_files'
+stderr 'bin/run arguments: update_graph'
 
 exec docker rmi -f graph-updater
 


### PR DESCRIPTION
- stacked on #502

This allows for `graph` commands to work in smoke tests by adding a top-level `command` to the smoke test file. 