### PR TITLE
Differentiate between cmd input and model input exclusivity

### DIFF
--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -146,18 +146,25 @@ func NewUpdateCommand() *cobra.Command {
 
 func extractInput(cmd *cobra.Command, flags *UpdateFlags) (*model.Input, error) {
 	hasFile := flags.file != ""
-	hasArguments := len(cmd.Flags().Args()) > 0
+	args := cmd.Flags().Args()
+	filteredArgs := []string{}
+	for i := 0; i < len(args); i++ {
+		if args[i] != "-f" && args[i] != "--file" {
+			filteredArgs = append(filteredArgs, args[i])
+		}
+	}
+	hasArguments := len(filteredArgs) > 0
 	hasServer := flags.inputServerPort != 0
 	hasStdin := doesStdinHaveData()
 
 	var count int
-	for _, b := range []bool{hasFile, hasArguments, hasServer, hasStdin} {
+	for _, b := range []bool{hasFile, hasArguments, hasStdin} {
 		if b {
 			count++
 		}
 	}
 	if count > 1 {
-		return nil, errors.New("can only use one of: input file, arguments, server, or stdin")
+		return nil, errors.New("can only use one of: input file, arguments, or stdin")
 	}
 
 	if hasFile {


### PR DESCRIPTION
In https://github.com/dependabot/cli/issues/506, I noticed that parsing flags and model input to the Dependabot job had some scenarios that collide.

This fix ignores the `-f` or `--file` flags when deciding if the command `hasArguments` because this would mean `hasFile` was specified by these arguments, and therefore should only check for additional arguments. There might be some more idiomatic way to do this...

I also excluded `hasServer` from the args checker because it also collides with `hasArguments`.

Still need to address how Model Input is created from these new possible scenarios.

Would love feedback, @jakecoffman.