### PR TITLE
Update the CLI input parsing to always use directories instead of directory, Default branch to `main` for graph jobs

### DIFF
--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -269,7 +269,7 @@ func readArguments(cmd *cobra.Command, flags *UpdateFlags) (*model.Input, error)
 			Source: model.Source{
 				Provider:    flags.provider,
 				Repo:        repo,
-				Directory:   flags.directory,
+				Directories: []string{flags.directory},
 				Commit:      flags.commit,
 				Branch:      flags.branch,
 				Hostname:    &hostname,

--- a/testdata/scripts/input.txt
+++ b/testdata/scripts/input.txt
@@ -19,7 +19,7 @@ dependabot update go_modules dependabot/cli --dep golang.org/x/image --updater-i
 stderr '"allowed-updates":\[\{"dependency-name":"golang.org/x/image"\}\]'
 
 dependabot update go_modules dependabot/cli --directory /code --updater-image input-verify-updater
-stderr '"directory":"\/code"'
+stderr '"directories":\["\/code"\]'
 
 exec docker rmi -f input-verify-updater
 


### PR DESCRIPTION
This PR makes the CLI compatible with the changes to the grapher introduced here:
- https://github.com/dependabot/dependabot-core/pull/13128

When running a graph command Dependabot Core needs the following preconditions to be true:
- `job.source.directories` must be used, `job.source.directory` is not supported for this command
- ~~`job.source.branch` **must be specified**, so the cli now defaults this to `main` for convenience.~~
