### PR TITLE
Pass OIDC environment variables to proxy

### DIFF
--- a/internal/infra/proxy.go
+++ b/internal/infra/proxy.go
@@ -4,6 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
@@ -11,11 +17,6 @@ import (
 	"github.com/goware/prefixer"
 	"github.com/moby/moby/pkg/namesgenerator"
 	"github.com/moby/moby/pkg/stdcopy"
-	"io"
-	"log"
-	"os"
-	"path"
-	"path/filepath"
 )
 
 const proxyCertPath = "/usr/local/share/ca-certificates/custom-ca-cert.crt"
@@ -85,6 +86,8 @@ func NewProxy(ctx context.Context, cli *client.Client, params *RunParams, nets *
 			"JOB_ID=" + jobID,
 			"PROXY_CACHE=true",
 			"LOG_RESPONSE_BODY_ON_AUTH_FAILURE=true",
+			"ACTIONS_ID_TOKEN_REQUEST_TOKEN=" + os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN"),
+			"ACTIONS_ID_TOKEN_REQUEST_URL=" + os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL"),
 		},
 		Entrypoint: []string{
 			"sh", "-c", "update-ca-certificates && /update-job-proxy",


### PR DESCRIPTION
This change passes the `ACTIONS_ID_TOKEN_REQUEST_TOKEN` and `ACTIONS_ID_TOKEN_REQUEST_URL` from GitHub Actions to the Dependabot proxy container.

It's the first part of the feature to allow to proxy to use OIDC federated credentials for authentication to private registries.

Eqivalent of https://github.com/github/dependabot-action/pull/1544

References:
- [Configuring OpenID Connect in cloud providers][1]
- [OpenID Connect reference][2]

[1]: https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-cloud-providers#requesting-the-jwt-using-environment-variables
[2]: https://docs.github.com/en/actions/reference/security/oidc#methods-for-requesting-the-oidc-token