### PR TITLE
ignore detector version when testing dependency submission

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -315,6 +315,11 @@ func unexpectedBody(kind string) error {
 }
 
 func compareDependencySubmissionRequest(expect, actual model.DependencySubmissionRequest) error {
+	// since the detector version will change all the time, ignore that in the comparison
+	tmp := expect.Detector["version"]
+	defer func() { expect.Detector["version"] = tmp }()
+	expect.Detector["version"] = actual.Detector["version"]
+
 	if reflect.DeepEqual(expect, actual) {
 		return nil
 	}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -7,10 +7,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/dependabot/cli/internal/model"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/dependabot/cli/internal/model"
 )
 
 func Test_decodeWrapper(t *testing.T) {
@@ -102,4 +103,29 @@ func TestAPI_CreatePullRequest_ReplacesBinaryWithHash(t *testing.T) {
 	if wrapper.Data.UpdatedDependencyFiles[0].Content != content {
 		t.Errorf("expected stdout to contain the original content, got '%s'", stdout.String())
 	}
+}
+
+func TestAPI_compareDependencySubmissionRequest(t *testing.T) {
+	t.Run("ignores detector version", func(t *testing.T) {
+		expect := model.DependencySubmissionRequest{
+			Detector: map[string]any{
+				"version": "1.2.3",
+			},
+		}
+		actual := model.DependencySubmissionRequest{
+			Detector: map[string]any{
+				"version": "4.5.6",
+			},
+		}
+
+		if compareDependencySubmissionRequest(expect, actual) != nil {
+			t.Error("expected detector version to be ignored")
+		}
+		if expect.Detector["version"] != "1.2.3" {
+			t.Error("expected expect detector version to be unchanged")
+		}
+		if actual.Detector["version"] != "4.5.6" {
+			t.Error("expected actual detector version to be unchanged")
+		}
+	})
 }


### PR DESCRIPTION
When using the graph command we record the version of dependabot-core. This is bad for smoke testing because we'd constantly need to be updating that version. 

Instead, let's ignore the version when asserting in a test.