### PR TITLE
handle version command the same as update

### DIFF
--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -31,6 +31,7 @@ import (
 )
 
 var runCmds = map[model.RunCommand]string{
+	model.VersionCommand:     "bin/run fetch_files && bin/run update_files",
 	model.UpdateFilesCommand: "bin/run fetch_files && bin/run update_files",
 	model.RecreateCommand:    "bin/run fetch_files && bin/run update_files",
 	model.SecurityCommand:    "bin/run fetch_files && bin/run update_files",

--- a/internal/model/smoke.go
+++ b/internal/model/smoke.go
@@ -4,6 +4,7 @@ type RunCommand string
 
 const (
 	UpdateFilesCommand RunCommand = "update"
+	VersionCommand     RunCommand = "version"
 	RecreateCommand    RunCommand = "recreate"
 	SecurityCommand    RunCommand = "security"
 	UpdateGraphCommand RunCommand = "graph"


### PR DESCRIPTION
- follow-on to https://github.com/dependabot/cli/pull/532

The command naming is still in flux, handling the "version" command here too before refactoring which should make these obsolete.