### PR TITLE
Add jit access endpoint support in the cli

### DIFF
--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -365,8 +365,8 @@ func processInput(input *model.Input, flags *UpdateFlags) {
 			log.Println("Adding jit_access type for GitHub credentials")
 			input.Credentials = append(input.Credentials, model.Credential{
 				"type":            "jit_access",
+				"host":            host,
 				"credential-type": "git_source",
-				"username":        "x-access-token",
 				"endpoint":        "$GITHUB_JITACCESS_TOKEN_ENDPOINT",
 			})
 		}

--- a/cmd/dependabot/internal/cmd/update_test.go
+++ b/cmd/dependabot/internal/cmd/update_test.go
@@ -227,8 +227,8 @@ func Test_processInput(t *testing.T) {
 		}
 		if !reflect.DeepEqual(input.Credentials[1], model.Credential{
 			"type":            "jit_access",
+			"host":            host,
 			"credential-type": "git_source",
-			"username":        "x-access-token",
 			"endpoint":        "$GITHUB_JITACCESS_TOKEN_ENDPOINT",
 		}) {
 			t.Error("expected jit_access credentials to be added")
@@ -242,9 +242,10 @@ func Test_processInput(t *testing.T) {
 		if !reflect.DeepEqual(input.Job.CredentialsMetadata[1], model.Credential{
 			"type":            "jit_access",
 			"credential-type": "git_source",
+			"host":            host,
 			"endpoint":        "$GITHUB_JITACCESS_TOKEN_ENDPOINT",
 		}) {
-			t.Error("expected jit_accesscredentials metadata to be added")
+			t.Error("expected jit_access credentials metadata to be added")
 		}
 	})
 }


### PR DESCRIPTION
Add a new env var `$GITHUB_JITACCESS_TOKEN_ENDPOINT` for jit_access endpoint support. The goal here is to allow the proxy to query this endpoint for a new token when our original credentials expire (requests started getting Unauthorize response).