### PR TITLE
Add golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,15 @@
+version: "2"
+
+linters:
+  default: standard
+  enable:
+    - bodyclose
+    - errorlint
+    - gocritic
+    - gosec
+    - misspell
+    - noctx
+    - prealloc
+
+issues:
+  max-same-issues: 0


### PR DESCRIPTION
Adds a `.golangci.yml` (v2 format) to give the repo a consistent linter setup.

The config uses the `standard` default set (`errcheck`, `govet`, `ineffassign`, `staticcheck`, `unused`) and turns on a few extras that catch real bugs without being too noisy:

- `bodyclose` — unclosed HTTP response bodies
- `errorlint` — incorrect error wrapping
- `gocritic` — common code style issues
- `gosec` — security problems
- `misspell` — typos
- `noctx` — missing context in HTTP/net calls
- `prealloc` — slice preallocation hints

We already have `golangci-lint` in the Brewfile but no config, so everyone either runs different linters or none at all. This gets us to a shared baseline.

There are ~55 existing findings (mostly `errcheck`). Fixing those and wiring this into CI are separate follow-ups.

Closes #561