### PR TITLE
Fix gocritic warnings

### DIFF
--- a/internal/infra/proxy.go
+++ b/internal/infra/proxy.go
@@ -182,7 +182,7 @@ func (p *Proxy) Close() (err error) {
 	}()
 
 	// Check the error code if the container has already exited, so we can pass it along to the caller. If the proxy
-	//crashes we want the CLI to error out.
+	// crashes we want the CLI to error out.
 	containerInfo, inspectErr := p.cli.ContainerInspect(context.Background(), p.containerID)
 	if inspectErr != nil {
 		return fmt.Errorf("failed to inspect proxy container: %w", inspectErr)

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -608,8 +608,8 @@ func pullImage(ctx context.Context, cli *client.Client, imageName string) error 
 func pullImageWithAuth(ctx context.Context, cli *client.Client, imageName string) error {
 	var imagePullOptions image.PullOptions
 
-	if strings.HasPrefix(imageName, "ghcr.io/") {
-
+	switch {
+	case strings.HasPrefix(imageName, "ghcr.io/"):
 		token := os.Getenv("LOCAL_GITHUB_ACCESS_TOKEN")
 		if token != "" {
 			auth := base64.StdEncoding.EncodeToString([]byte("x:" + token))
@@ -619,7 +619,7 @@ func pullImageWithAuth(ctx context.Context, cli *client.Client, imageName string
 		} else {
 			log.Println("Failed to find credentials for GitHub container registry.")
 		}
-	} else if strings.Contains(imageName, ".azurecr.io/") {
+	case strings.Contains(imageName, ".azurecr.io/"):
 		username := os.Getenv("AZURE_REGISTRY_USERNAME")
 		password := os.Getenv("AZURE_REGISTRY_PASSWORD")
 
@@ -641,7 +641,7 @@ func pullImageWithAuth(ctx context.Context, cli *client.Client, imageName string
 		} else {
 			log.Println("Failed to find credentials for Azure container registry.")
 		}
-	} else {
+	default:
 		log.Printf("Failed to find credentials for pulling image: %s\n.", imageName)
 	}
 

--- a/internal/model/job_test.go
+++ b/internal/model/job_test.go
@@ -291,8 +291,7 @@ func compareMap(t *testing.T, parent string, expected map[string]any, actual int
 			case []any:
 				// Also check structs that are in arrays.
 				for _, v := range expectedValue {
-					switch v := v.(type) {
-					case map[string]any:
+					if v, ok := v.(map[string]any); ok {
 						structField := actualType.Field(fieldIndex)
 						name := yamlTagCleaner(structField.Tag.Get("yaml"))
 						compareMap(t, parent+"->"+name, v, actualValue.Interface())


### PR DESCRIPTION
Fixes the 3 gocritic warnings that show up when running `golangci-lint run ./...`:

- **proxy.go** — missing space between `//` and comment text
- **run.go** — `if/else if/else` chain in `pullImageWithAuth` converted to a `switch`
- **job_test.go** — single-case type switch replaced with an `if` + type assertion

All mechanical, no behavior changes.