### PR TITLE
Preallocate slice in update_test.go

### DIFF
--- a/cmd/dependabot/internal/cmd/update_test.go
+++ b/cmd/dependabot/internal/cmd/update_test.go
@@ -191,7 +191,7 @@ func Test_processInput(t *testing.T) {
 			}
 		}
 
-		actualCredentialsMetadataHosts := []string{}
+		actualCredentialsMetadataHosts := make([]string, 0, len(credentialsMetadataHosts))
 		for host := range credentialsMetadataHosts {
 			actualCredentialsMetadataHosts = append(actualCredentialsMetadataHosts, host)
 		}


### PR DESCRIPTION
Fixes the `prealloc` golangci-lint warning in `update_test.go`.

The `actualCredentialsMetadataHosts` slice was being initialized as an empty literal and grown via `append` in a loop over `credentialsMetadataHosts`. Since the map length is known at that point, we can pass it to `make()` and skip the reallocations.