### PR TITLE
Close HTTP response bodies to fix bodyclose lint

### DIFF
--- a/cmd/dependabot/internal/cmd/update_test.go
+++ b/cmd/dependabot/internal/cmd/update_test.go
@@ -295,10 +295,11 @@ func Test_extractInput(t *testing.T) {
 			// Retry the calls in case the server takes a bit to start up.
 			for i := 0; i < 10; i++ {
 				body := strings.NewReader(`{"job":{"package-manager":"go_modules"}}`)
-				_, err := http.Post("http://127.0.0.1:8080", "application/json", body)
+				resp, err := http.Post("http://127.0.0.1:8080", "application/json", body)
 				if err != nil {
 					time.Sleep(10 * time.Millisecond)
 				} else {
+					resp.Body.Close()
 					return
 				}
 			}

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -255,6 +255,7 @@ func checkCredAccess(ctx context.Context, job *model.Job, creds []model.Credenti
 		if err != nil {
 			return fmt.Errorf("failed making request: %w", err)
 		}
+		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("failed request to GitHub API to check access: %s", resp.Status)
 		}


### PR DESCRIPTION
golangci-lint's `bodyclose` checker flagged two unclosed HTTP response bodies:

- **`cmd/dependabot/internal/cmd/update_test.go`** — `http.Post` response was discarded (`_, err := ...`). Now we capture the response and call `resp.Body.Close()` before returning from the retry loop.
- **`internal/infra/run.go` (`checkCredAccess`)** — the response from the GitHub API token-scope check was never closed. Added `defer resp.Body.Close()` after the error check.