### PR TITLE
Fix noctx lint errors

### DIFF
--- a/cmd/dependabot/dependabot_test.go
+++ b/cmd/dependabot/dependabot_test.go
@@ -12,15 +12,14 @@ import (
 )
 
 func TestDependabot(t *testing.T) {
-	err := exec.Command("go", "build", ".").Run()
+	ctx := context.Background()
+	err := exec.CommandContext(ctx, "go", "build", ".").Run()
 	if err != nil {
 		t.Fatal("failed to build dependabot")
 	}
 	t.Cleanup(func() {
 		os.Remove("dependabot")
 	})
-
-	ctx := context.Background()
 	engine := &script.Engine{
 		Conds: scripttest.DefaultConds(),
 		Cmds:  Commands(),

--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -169,7 +169,7 @@ func extractInput(cmd *cobra.Command, flags *UpdateFlags) (*model.Input, error) 
 	}
 
 	if hasServer {
-		l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", flags.inputServerPort))
+		l, err := (&net.ListenConfig{}).Listen(cmd.Context(), "tcp", fmt.Sprintf("127.0.0.1:%d", flags.inputServerPort))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create listener: %w", err)
 		}

--- a/cmd/dependabot/internal/cmd/update_test.go
+++ b/cmd/dependabot/internal/cmd/update_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -295,7 +296,12 @@ func Test_extractInput(t *testing.T) {
 			// Retry the calls in case the server takes a bit to start up.
 			for i := 0; i < 10; i++ {
 				body := strings.NewReader(`{"job":{"package-manager":"go_modules"}}`)
-				resp, err := http.Post("http://127.0.0.1:8080", "application/json", body)
+				req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://127.0.0.1:8080", body)
+				if err != nil {
+					return
+				}
+				req.Header.Set("Content-Type", "application/json")
+				resp, err := http.DefaultClient.Do(req)
 				if err != nil {
 					time.Sleep(10 * time.Millisecond)
 				} else {

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -56,7 +56,7 @@ func NewAPI(expected []model.Output, writer io.Writer) *API {
 	if os.Getenv("FAKE_API_PORT") != "" {
 		port = os.Getenv("FAKE_API_PORT")
 	}
-	l, err := net.Listen("tcp", fakeAPIHost+":"+port)
+	l, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", fakeAPIHost+":"+port)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -67,7 +68,7 @@ func TestAPI_CreatePullRequest_ReplacesBinaryWithHash(t *testing.T) {
 
 	url := "http://127.0.0.1:" + // use the API's port
 		fmt.Sprintf("%d/create_pull_request", api.Port())
-	req, err := http.NewRequest("POST", url, &body)
+	req, err := http.NewRequestWithContext(context.Background(), "POST", url, &body)
 	if err != nil {
 		t.Fatalf("failed to create request: %v", err)
 	}

--- a/internal/server/input_test.go
+++ b/internal/server/input_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -20,7 +21,7 @@ func TestInput(t *testing.T) {
 	if os.Getenv("GOOS") == "darwin" {
 		ip = "127.0.0.1"
 	}
-	l, err := net.Listen("tcp", ip+":0")
+	l, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", ip+":0")
 	if err != nil {
 		t.Fatal("Failed to create listener: ", err.Error())
 	}


### PR DESCRIPTION
Six places in the codebase call `net.Listen`, `exec.Command`, `http.Post`, or `http.NewRequest` without a context, which trips the `noctx` linter.

This replaces each one with its context-aware equivalent:

- `exec.Command` → `exec.CommandContext`
- `net.Listen` → `(*net.ListenConfig).Listen`
- `http.Post` → `http.NewRequestWithContext` + `http.DefaultClient.Do`
- `http.NewRequest` → `http.NewRequestWithContext`