### PR TITLE
Fix all gosec security lint violations

### DIFF
--- a/cmd/dependabot/internal/cmd/test.go
+++ b/cmd/dependabot/internal/cmd/test.go
@@ -85,7 +85,7 @@ var testCmd = NewTestCommand()
 func readSmokeTest(file string) (*model.SmokeTest, []byte, error) {
 	var smokeTest model.SmokeTest
 
-	data, err := os.ReadFile(file)
+	data, err := os.ReadFile(file) //nolint:gosec // file path is provided by the user via CLI flags
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to open smoke test: %w", err)
 	}

--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -285,7 +285,7 @@ func readArguments(cmd *cobra.Command, flags *UpdateFlags) (*model.Input, error)
 func readInputFile(file string) (*model.Input, error) {
 	var input model.Input
 
-	data, err := os.ReadFile(file)
+	data, err := os.ReadFile(file) //nolint:gosec // file path is provided by the user via CLI flags
 	if err != nil {
 		return nil, fmt.Errorf("failed to open input file: %w", err)
 	}

--- a/internal/infra/proxy.go
+++ b/internal/infra/proxy.go
@@ -69,7 +69,7 @@ func NewProxy(ctx context.Context, cli *client.Client, params *RunParams, nets *
 	}
 	hostCfg.ExtraHosts = append(hostCfg.ExtraHosts, params.ExtraHosts...)
 	if params.CacheDir != "" {
-		_ = os.MkdirAll(params.CacheDir, 0744)
+		_ = os.MkdirAll(params.CacheDir, 0750)
 		cacheDir, _ := filepath.Abs(params.CacheDir)
 		hostCfg.Mounts = append(hostCfg.Mounts, mount.Mount{
 			Type:   mount.TypeBind,

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -130,7 +130,7 @@ func Run(params RunParams) error {
 		var err error
 		// Open a file for writing but don't truncate it yet since an error will delete the test.
 		// This is done before the test so if the dir isn't writable it doesn't waste time.
-		outFile, err = os.OpenFile(params.Output, os.O_RDWR|os.O_CREATE, 0666)
+		outFile, err = os.OpenFile(params.Output, os.O_RDWR|os.O_CREATE, 0600)
 		if err != nil {
 			return fmt.Errorf("failed to create output file: %w", err)
 		}
@@ -499,7 +499,7 @@ func getFromContainer(ctx context.Context, cli *client.Client, containerID, srcP
 	defer outFile.Close()
 	tarReader := tar.NewReader(reader)
 	tarReader.Next()
-	_, err = io.Copy(outFile, tarReader)
+	_, err = io.Copy(outFile, io.LimitReader(tarReader, 1<<30)) // 1 GiB limit to prevent decompression bombs
 	if err != nil {
 		log.Printf("Failed copy while getting from container %v: %v\n", srcPath, err)
 	}

--- a/internal/infra/run_test.go
+++ b/internal/infra/run_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func Test_checkCredAccess(t *testing.T) {
-	l, err := net.Listen("tcp", ":0")
+	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal("Failed to create listener: ", err.Error())
 	}

--- a/internal/server/input.go
+++ b/internal/server/input.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/dependabot/cli/internal/model"
 	"log"
 	"net"
 	"net/http"
+	"time"
+
+	"github.com/dependabot/cli/internal/model"
 )
 
 type credServer struct {
@@ -30,7 +32,7 @@ func (s *credServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // Input receives configuration via HTTP on the port and returns it decoded
 func Input(listener net.Listener) (*model.Input, error) {
 	handler := &credServer{}
-	srv := &http.Server{Handler: handler}
+	srv := &http.Server{Handler: handler, ReadHeaderTimeout: 10 * time.Second}
 	handler.server = srv
 
 	// printing so the user doesn't think the cli is hanging

--- a/internal/server/input_test.go
+++ b/internal/server/input_test.go
@@ -36,7 +36,7 @@ func TestInput(t *testing.T) {
 
 	url := fmt.Sprintf("http://%s", l.Addr().String())
 	data := `{"job":{"package-manager":"test"},"credentials":[{"credential":"value"}]}`
-	resp, err := http.Post(url, "application/json", bytes.NewReader([]byte(data)))
+	resp, err := http.Post(url, "application/json", bytes.NewReader([]byte(data))) //nolint:gosec // test code with controlled URL
 	if err != nil {
 		t.Fatal(err.Error())
 	}


### PR DESCRIPTION
Resolves the 8 gosec findings reported by golangci-lint.

**What changed:**

- Directory permissions for the cache dir: `0744` → `0750` (G301)
- Output file permissions: `0666` → `0600` (G302)
- Flamegraph tar extraction now uses `io.LimitReader` with a 1 GiB cap instead of unbounded `io.Copy` (G110)
- The HTTP input server sets `ReadHeaderTimeout: 10s` to prevent Slowloris-style attacks (G112)
- Test listener binds to `127.0.0.1` instead of all interfaces (G102)
- Added `nolint:gosec` on two lines where the warnings are false positives: user-supplied file paths from CLI flags (G304) and a test URL built from a controlled localhost listener (G107)