### PR TITLE
Update go from 1.25.0 to 1.26.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Dependabot CLI",
-  "image": "mcr.microsoft.com/devcontainers/go:1.25",
+  "image": "mcr.microsoft.com/devcontainers/go:1.26",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker": "latest"
   },

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dependabot/cli
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0


### PR DESCRIPTION
https://go.dev/doc/go1.26