### PR TITLE
Add UpdateTypes field to Allowed struct

### DIFF
--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -203,9 +203,10 @@ type ExistingGroupPR struct {
 }
 
 type Allowed struct {
-	DependencyType string `json:"dependency-type,omitempty" yaml:"dependency-type,omitempty"`
-	DependencyName string `json:"dependency-name,omitempty" yaml:"dependency-name,omitempty"`
-	UpdateType     string `json:"update-type,omitempty" yaml:"update-type,omitempty"`
+	DependencyType string   `json:"dependency-type,omitempty" yaml:"dependency-type,omitempty"`
+	DependencyName string   `json:"dependency-name,omitempty" yaml:"dependency-name,omitempty"`
+	UpdateType     string   `json:"update-type,omitempty" yaml:"update-type,omitempty"`
+	UpdateTypes    []string `json:"update-types,omitempty" yaml:"update-types,omitempty"`
 }
 
 type Group struct {

--- a/internal/model/job_test.go
+++ b/internal/model/job_test.go
@@ -69,21 +69,45 @@ func TestAllowedUpdateTypesJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var decoded Allowed
-	if err := json.Unmarshal(data, &decoded); err != nil {
+	// Verify the actual JSON keys are correct by unmarshaling into a raw map
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
 		t.Fatal(err)
 	}
 
-	if decoded.DependencyName != original.DependencyName {
-		t.Errorf("dependency-name: expected %q, got %q", original.DependencyName, decoded.DependencyName)
+	if _, ok := raw["update-types"]; !ok {
+		t.Errorf("expected JSON key \"update-types\" to be present, got keys: %v", raw)
 	}
-	if len(decoded.UpdateTypes) != len(original.UpdateTypes) {
-		t.Fatalf("update-types length: expected %d, got %d", len(original.UpdateTypes), len(decoded.UpdateTypes))
+	if _, ok := raw["dependency-name"]; !ok {
+		t.Errorf("expected JSON key \"dependency-name\" to be present, got keys: %v", raw)
 	}
-	for i, et := range original.UpdateTypes {
-		if decoded.UpdateTypes[i] != et {
-			t.Errorf("update-types[%d]: expected %q, got %q", i, et, decoded.UpdateTypes[i])
+
+	types, ok := raw["update-types"].([]any)
+	if !ok {
+		t.Fatalf("expected update-types to be an array, got %T", raw["update-types"])
+	}
+	expectedTypes := []string{"version-update:semver-minor", "version-update:semver-patch"}
+	if len(types) != len(expectedTypes) {
+		t.Fatalf("expected %d update-types, got %d", len(expectedTypes), len(types))
+	}
+	for i, et := range expectedTypes {
+		if types[i] != et {
+			t.Errorf("update-types[%d]: expected %q, got %q", i, et, types[i])
 		}
+	}
+
+	// Verify omitempty: UpdateTypes should be absent when nil
+	empty := Allowed{DependencyName: "rails"}
+	data, err = json.Marshal(empty)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rawEmpty map[string]any
+	if err := json.Unmarshal(data, &rawEmpty); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := rawEmpty["update-types"]; ok {
+		t.Errorf("expected \"update-types\" to be omitted when nil, but it was present")
 	}
 }
 

--- a/internal/model/job_test.go
+++ b/internal/model/job_test.go
@@ -69,31 +69,10 @@ func TestAllowedUpdateTypesJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Verify the actual JSON keys are correct by unmarshaling into a raw map
-	var raw map[string]any
-	if err := json.Unmarshal(data, &raw); err != nil {
-		t.Fatal(err)
-	}
-
-	if _, ok := raw["update-types"]; !ok {
-		t.Errorf("expected JSON key \"update-types\" to be present, got keys: %v", raw)
-	}
-	if _, ok := raw["dependency-name"]; !ok {
-		t.Errorf("expected JSON key \"dependency-name\" to be present, got keys: %v", raw)
-	}
-
-	types, ok := raw["update-types"].([]any)
-	if !ok {
-		t.Fatalf("expected update-types to be an array, got %T", raw["update-types"])
-	}
-	expectedTypes := []string{"version-update:semver-minor", "version-update:semver-patch"}
-	if len(types) != len(expectedTypes) {
-		t.Fatalf("expected %d update-types, got %d", len(expectedTypes), len(types))
-	}
-	for i, et := range expectedTypes {
-		if types[i] != et {
-			t.Errorf("update-types[%d]: expected %q, got %q", i, et, types[i])
-		}
+	// Verify marshaled JSON directly without using unmarshal
+	expected := `{"dependency-name":"rails","update-types":["version-update:semver-minor","version-update:semver-patch"]}`
+	if string(data) != expected {
+		t.Errorf("unexpected JSON output:\n  got:  %s\n  want: %s", string(data), expected)
 	}
 
 	// Verify omitempty: UpdateTypes should be absent when nil
@@ -102,12 +81,10 @@ func TestAllowedUpdateTypesJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var rawEmpty map[string]any
-	if err := json.Unmarshal(data, &rawEmpty); err != nil {
-		t.Fatal(err)
-	}
-	if _, ok := rawEmpty["update-types"]; ok {
-		t.Errorf("expected \"update-types\" to be omitted when nil, but it was present")
+
+	expectedEmpty := `{"dependency-name":"rails"}`
+	if string(data) != expectedEmpty {
+		t.Errorf("unexpected JSON output for empty UpdateTypes:\n  got:  %s\n  want: %s", string(data), expectedEmpty)
 	}
 }
 

--- a/internal/model/job_test.go
+++ b/internal/model/job_test.go
@@ -21,6 +21,72 @@ func TestInput(t *testing.T) {
 	compareMap(t, "job", input2["job"], input.Job)
 }
 
+func TestAllowedUpdateTypes(t *testing.T) {
+	var input Input
+	if err := yaml.Unmarshal([]byte(exampleJob), &input); err != nil {
+		t.Fatal(err)
+	}
+
+	allowed := input.Job.AllowedUpdates
+	if len(allowed) != 2 {
+		t.Fatalf("expected 2 allowed updates, got %d", len(allowed))
+	}
+
+	// First entry: dependency-type + update-type (existing pattern)
+	if allowed[0].DependencyType != "direct" {
+		t.Errorf("expected dependency-type 'direct', got %q", allowed[0].DependencyType)
+	}
+	if allowed[0].UpdateType != "all" {
+		t.Errorf("expected update-type 'all', got %q", allowed[0].UpdateType)
+	}
+	if len(allowed[0].UpdateTypes) != 0 {
+		t.Errorf("expected no update-types on first entry, got %v", allowed[0].UpdateTypes)
+	}
+
+	// Second entry: dependency-name + update-types (new feature)
+	if allowed[1].DependencyName != "rails" {
+		t.Errorf("expected dependency-name 'rails', got %q", allowed[1].DependencyName)
+	}
+	expectedTypes := []string{"version-update:semver-minor", "version-update:semver-patch"}
+	if len(allowed[1].UpdateTypes) != len(expectedTypes) {
+		t.Fatalf("expected %d update-types, got %d", len(expectedTypes), len(allowed[1].UpdateTypes))
+	}
+	for i, et := range expectedTypes {
+		if allowed[1].UpdateTypes[i] != et {
+			t.Errorf("update-types[%d]: expected %q, got %q", i, et, allowed[1].UpdateTypes[i])
+		}
+	}
+}
+
+func TestAllowedUpdateTypesJSON(t *testing.T) {
+	original := Allowed{
+		DependencyName: "rails",
+		UpdateTypes:    []string{"version-update:semver-minor", "version-update:semver-patch"},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded Allowed
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	if decoded.DependencyName != original.DependencyName {
+		t.Errorf("dependency-name: expected %q, got %q", original.DependencyName, decoded.DependencyName)
+	}
+	if len(decoded.UpdateTypes) != len(original.UpdateTypes) {
+		t.Fatalf("update-types length: expected %d, got %d", len(original.UpdateTypes), len(decoded.UpdateTypes))
+	}
+	for i, et := range original.UpdateTypes {
+		if decoded.UpdateTypes[i] != et {
+			t.Errorf("update-types[%d]: expected %q, got %q", i, et, decoded.UpdateTypes[i])
+		}
+	}
+}
+
 func TestExistingPullRequestsNewFormat(t *testing.T) {
 	testYAML := `---
 job:
@@ -663,6 +729,10 @@ job:
   allowed-updates:
   - dependency-type: direct
     update-type: all
+  - dependency-name: "rails"
+    update-types:
+    - "version-update:semver-minor"
+    - "version-update:semver-patch"
   dependency-groups:
   - name: npm
     rules:


### PR DESCRIPTION
## Summary

Add `UpdateTypes []string` field to the `Allowed` struct, enabling `update-types` support in the `allow` block of `dependabot.yml`.

This matches the existing pattern in the `Condition` (ignore) struct which already has `UpdateTypes []string` at line 221.

## Changes

- `internal/model/job.go`: Add `UpdateTypes []string` field to `Allowed` struct with `json:"update-types,omitempty" yaml:"update-types,omitempty"` tags
- `internal/model/job_test.go`: Add `update-types` to `exampleJob` fixture, add `TestAllowedUpdateTypes` (YAML unmarshal) and `TestAllowedUpdateTypesJSON` (JSON round-trip) tests

## Related PRs

- Core: dependabot/dependabot-core#12925 (updater logic)
- API: github/dependabot-api#8052 (schema, parser, validator, serializer)

Relates to dependabot/dependabot-core#12668.