### PR TITLE
Skip auto-generated ignore conditions for git SHA versions

### DIFF
--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -178,7 +178,7 @@ func generateOutput(params RunParams, api *server.API, outFile *os.File) ([]byte
 	api.Actual.Input.Job = *params.Job
 
 	// ignore conditions help make tests reproducible, so they are generated if there aren't any yet
-	if len(api.Actual.Input.Job.IgnoreConditions) == 0 && api.Actual.Input.Job.PackageManager != "submodules" {
+	if len(api.Actual.Input.Job.IgnoreConditions) == 0 {
 		if err := generateIgnoreConditions(&params, &api.Actual); err != nil {
 			return nil, err
 		}
@@ -342,6 +342,8 @@ func expandEnvironmentVariables(api *server.API, params *RunParams) {
 	}
 }
 
+var gitShaVersion = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
 func generateIgnoreConditions(params *RunParams, actual *model.SmokeTest) error {
 	for _, out := range actual.Output {
 		if out.Type == "create_pull_request" {
@@ -353,6 +355,11 @@ func generateIgnoreConditions(params *RunParams, actual *model.SmokeTest) error 
 			for _, dep := range createPR.Dependencies {
 				if dep.Version == nil {
 					// dependency version nil due to it being removed
+					continue
+				}
+				if gitShaRegex.MatchString(*dep.Version) {
+					// Git SHAs (used by submodules, nix flake inputs, etc.) cannot be
+					// expressed as a Gem::Requirement, so skip those individual conditions.
 					continue
 				}
 				ignore := model.Condition{

--- a/internal/infra/run_test.go
+++ b/internal/infra/run_test.go
@@ -158,4 +158,32 @@ func Test_generateIgnoreConditions(t *testing.T) {
 			t.Error("expected 0 ignore condition to be generated, got", len(actual.Input.Job.IgnoreConditions))
 		}
 	})
+
+	t.Run("skips git SHA versions", func(t *testing.T) {
+		runParams := &RunParams{
+			Output: outputFileName,
+		}
+		semver := "1.0.0"
+		sha := "8b27c1239e5c421a2bbc2c65d52e4a6fbf2ff296"
+		actual := &model.SmokeTest{
+			Output: []model.Output{{
+				Type: "create_pull_request",
+				Expect: model.UpdateWrapper{Data: model.CreatePullRequest{
+					Dependencies: []model.Dependency{
+						{Name: "semver-dep", Version: &semver},
+						{Name: "sha-dep", Version: &sha},
+					},
+				}},
+			}},
+		}
+		if err := generateIgnoreConditions(runParams, actual); err != nil {
+			t.Fatal(err)
+		}
+		if len(actual.Input.Job.IgnoreConditions) != 1 {
+			t.Fatalf("expected 1 ignore condition, got %d", len(actual.Input.Job.IgnoreConditions))
+		}
+		if actual.Input.Job.IgnoreConditions[0].DependencyName != "semver-dep" {
+			t.Errorf("expected semver-dep, got %q", actual.Input.Job.IgnoreConditions[0].DependencyName)
+		}
+	})
 }


### PR DESCRIPTION
`generateIgnoreConditions` adds a `version-requirement: '>X'` entry per `create_pull_request` output so regenerated smoke tests stay stable. When `X` is a 40-character git SHA, Ruby's `Gem::Requirement` rejects it (`BadRequirementError: Illformed requirement`) and the smoke test run fails.

The previous workaround was an inline `pm != "submodules"` check that disabled the whole ecosystem. That worked for submodules (always SHAs) but doesn't fit nix, which mixes SHA-pinned and tag-pinned (semver) flake inputs in the same lock file. Skipping the entire ecosystem would also skip the legitimate semver tag deps. See dependabot/smoke-tests#479 for the failure that prompted this.

This PR moves the check down to the individual condition: if a dependency's version matches a 40-character hex SHA, skip generating an ignore for it. Semver versions in any ecosystem still get one; SHAs are skipped wherever they appear. The existing `gitShaRegex` (already used to validate `Source.Commit`) is reused.

Test coverage: `Test_generateIgnoreConditions/skips_git_SHA_versions` asserts that a mixed dependency list produces a condition only for the semver entry.