### PR TITLE
Add sbt to package manager mapping

### DIFF
--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -295,6 +295,7 @@ var packageManagerLookup = map[string]string{
 	"pre_commit":     "pre-commit",
 	"pub":            "pub",
 	"rust_toolchain": "rust-toolchain",
+	"sbt":            "sbt",
 	"submodules":     "gitsubmodule",
 	"swift":          "swift",
 	"terraform":      "terraform",


### PR DESCRIPTION
This PR adds `sbt` to package manager lookup mapping.