### PR TITLE
Capture update_job warnings as well as errors

### DIFF
--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -79,6 +79,12 @@ type RecordUpdateJobUnknownError struct {
 	ErrorDetails map[string]any `json:"error-details" yaml:"error-details"`
 }
 
+type RecordUpdateJobWarning struct {
+	WarnType        string `json:"warn-type" yaml:"warn-type"`
+	WarnTitle       string `json:"warn-title" yaml:"warn-title"`
+	WarnDescription string `json:"warn-description" yaml:"warn-description"`
+}
+
 type IncrementMetric struct {
 	Metric string         `json:"metric" yaml:"metric"`
 	Tags   map[string]any `json:"tags" yaml:"tags"`

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -246,6 +246,8 @@ func decodeWrapper(kind string, data []byte) (actual *model.UpdateWrapper, err e
 		actual.Data, err = decode[model.RecordUpdateJobError](data)
 	case "record_update_job_unknown_error":
 		actual.Data, err = decode[model.RecordUpdateJobUnknownError](data)
+	case "record_update_job_warning":
+		actual.Data, err = decode[model.RecordUpdateJobWarning](data)
 	case "increment_metric":
 		actual.Data, err = decode[model.IncrementMetric](data)
 	default:
@@ -305,6 +307,8 @@ func compare(expect, actual *model.UpdateWrapper) error {
 		return compareRecordUpdateJobError(v, actual.Data.(model.RecordUpdateJobError))
 	case model.RecordUpdateJobUnknownError:
 		return compareRecordUpdateJobUnknownError(v, actual.Data.(model.RecordUpdateJobUnknownError))
+	case model.RecordUpdateJobWarning:
+		return compareRecordUpdateJobWarning(v, actual.Data.(model.RecordUpdateJobWarning))
 	case []model.RecordEcosystemMeta:
 		return compareRecordEcosystemMeta(v, actual.Data.([]model.RecordEcosystemMeta))
 	default:
@@ -382,6 +386,13 @@ func compareRecordUpdateJobUnknownError(expect, actual model.RecordUpdateJobUnkn
 		return nil
 	}
 	return unexpectedBody("record_update_job_unknown_error")
+}
+
+func compareRecordUpdateJobWarning(expect, actual model.RecordUpdateJobWarning) error {
+	if reflect.DeepEqual(expect, actual) {
+		return nil
+	}
+	return unexpectedBody("record_update_job_warning")
 }
 
 func compareRecordEcosystemMeta(expect, actual []model.RecordEcosystemMeta) error {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -181,6 +181,61 @@ func TestAPI_compareRecordEcosystemMeta(t *testing.T) {
 	})
 }
 
+func TestAPI_compareRecordUpdateJobWarning(t *testing.T) {
+	t.Run("matching warning", func(t *testing.T) {
+		warning := model.RecordUpdateJobWarning{
+			WarnType:        "warn_once",
+			WarnTitle:       "something to know",
+			WarnDescription: "more details here",
+		}
+		if err := compareRecordUpdateJobWarning(warning, warning); err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("mismatched warning", func(t *testing.T) {
+		expect := model.RecordUpdateJobWarning{WarnType: "warn_once", WarnTitle: "title-a", WarnDescription: "desc-a"}
+		actual := model.RecordUpdateJobWarning{WarnType: "warn_once", WarnTitle: "title-b", WarnDescription: "desc-b"}
+		if err := compareRecordUpdateJobWarning(expect, actual); err == nil {
+			t.Error("expected error for mismatched warning")
+		}
+	})
+
+	t.Run("compare via compare function", func(t *testing.T) {
+		warning := model.RecordUpdateJobWarning{
+			WarnType:        "warn_once",
+			WarnTitle:       "something to know",
+			WarnDescription: "more details here",
+		}
+		expectWrapper := &model.UpdateWrapper{Data: warning}
+		actualWrapper := &model.UpdateWrapper{Data: warning}
+		if err := compare(expectWrapper, actualWrapper); err != nil {
+			t.Errorf("expected no error from compare, got %v", err)
+		}
+	})
+
+	t.Run("decodeWrapper round-trip", func(t *testing.T) {
+		payload := []byte(`{"data": {"warn-type": "warn_once", "warn-title": "something to know", "warn-description": "more details here"}}`)
+		wrapper, err := decodeWrapper("record_update_job_warning", payload)
+		if err != nil {
+			t.Fatalf("unexpected decode error: %v", err)
+		}
+		warning, ok := wrapper.Data.(model.RecordUpdateJobWarning)
+		if !ok {
+			t.Fatalf("expected RecordUpdateJobWarning, got %T", wrapper.Data)
+		}
+		if warning.WarnType != "warn_once" {
+			t.Errorf("expected warn-type 'warn_once', got '%s'", warning.WarnType)
+		}
+		if warning.WarnTitle != "something to know" {
+			t.Errorf("expected warn-title 'something to know', got '%s'", warning.WarnTitle)
+		}
+		if warning.WarnDescription != "more details here" {
+			t.Errorf("expected warn-description 'more details here', got '%s'", warning.WarnDescription)
+		}
+	})
+}
+
 func TestAPI_compareDependencySubmissionRequest(t *testing.T) {
 	t.Run("ignores detector version", func(t *testing.T) {
 		expect := model.DependencySubmissionRequest{


### PR DESCRIPTION
When running the `update_graph` command in core, we have some scenarios that now produce calls to `record_update_job_warnings` instead of `record_update_job_errors` to record non-blocking problems during a run.

I'd like to add smoke-tests for some of these scenarios to `dependabot/smoke-tests` but first I need to add support here.

#### Example run

```
go run ./... test -f ../smoke-tests/tests/smoke-go-graph-private-no-creds.yaml
```

```
updater | {
updater |   "version": 1,
updater |   "sha": "6c7557f98092fee58a96b9f4cb1a0ec7e2472cb1",
updater |   "ref": "refs/heads/main",
updater |   "job": {
updater |     "correlator": "dependabot-go_modules-b643eab7160a61359bf52d40168d2deea7204e06d8e27384d7f27f461fc70bc1",
updater |     "id": "cli"
updater |   },
updater |   "detector": {
updater |     "name": "dependabot",
updater |     "version": "0.377.0",
updater |     "url": "https://github.com/dependabot/dependabot-core"
updater |   },
updater |   "manifests": {
updater |     "/go/graphs/private-packages-without-credentials/go.mod": {
updater |       "name": "/go/graphs/private-packages-without-credentials/go.mod",
updater |       "file": {
updater |         "source_location": "go/graphs/private-packages-without-credentials/go.mod"
updater |       },
updater |       "metadata": {
updater |         "ecosystem": "golang",
updater |         "blob_oid": "e9cbb2d39390e5a370d1fe3a94437f16e539878f"
updater |       },
updater |       "resolved": {
updater |         "pkg:golang/github.com/dependabot/sekret-project@v0.1.0": {
updater |           "package_url": "pkg:golang/github.com/dependabot/sekret-project@v0.1.0",
updater |           "relationship": "direct",
updater |           "scope": "runtime",
updater |           "dependencies": []
updater |         }
updater |       }
updater |     }
updater |   },
updater |   "metadata": {
updater |     "status": "degraded",
updater |     "reason": "error fetching sub-dependencies",
updater |     "scanned_manifest_path": "golang::/go/graphs/private-packages-without-credentials"
updater |   }
updater | }
```

```
input:
    job:
        command: graph
        package-manager: go_modules
        allowed-updates:
            - update-type: all
        source:
            provider: github
            repo: dependabot/smoke-tests
            directories:
                - /go/graphs/private-packages-without-credentials
            commit: 6c7557f98092fee58a96b9f4cb1a0ec7e2472cb1
            hostname: github.com
            api-endpoint: https://api.github.com
    credentials:
        - host: github.com
          password: $LOCAL_GITHUB_ACCESS_TOKEN
          type: git_source
          username: x-access-token
output:
    - type: record_update_job_warning
      expect:
        data:
            warn-type: dependency_graph_incomplete
            warn-title: dependency graph incomplete
            warn-description: 'The dependency graph may be incomplete. The following git URLs could not be retrieved: github.com/dependabot/sekret-project'
    - type: create_dependency_submission
      expect:
        data:
            version: 1
            sha: 6c7557f98092fee58a96b9f4cb1a0ec7e2472cb1
            ref: refs/heads/main
            job:
                correlator: dependabot-go_modules-b643eab7160a61359bf52d40168d2deea7204e06d8e27384d7f27f461fc70bc1
                id: cli
            detector:
                name: dependabot
                url: https://github.com/dependabot/dependabot-core
                version: 0.377.0
            manifests:
                /go/graphs/private-packages-without-credentials/go.mod:
                    file:
                        source_location: go/graphs/private-packages-without-credentials/go.mod
                    metadata:
                        blob_oid: e9cbb2d39390e5a370d1fe3a94437f16e539878f
                        ecosystem: golang
                    name: /go/graphs/private-packages-without-credentials/go.mod
                    resolved:
                        pkg:golang/github.com/dependabot/sekret-project@v0.1.0:
                            dependencies: []
                            package_url: pkg:golang/github.com/dependabot/sekret-project@v0.1.0
                            relationship: direct
                            scope: runtime
            metadata:
                reason: error fetching sub-dependencies
                scanned_manifest_path: golang::/go/graphs/private-packages-without-credentials
                status: degraded
    - type: mark_as_processed
      expect:
        data:
            base-commit-sha: 6c7557f98092fee58a96b9f4cb1a0ec7e2472cb1
```