### PR TITLE
Add cargo to Azure Artifacts credential type mapping

### DIFF
--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -42,6 +42,7 @@ type UpdateFlags struct {
 
 // A map of package manager names to credential type
 var azureArtifactsPackageManagerCredentialType = map[string]string{
+	"cargo":        "cargo_registry",
 	"gradle":       "maven_repository",
 	"maven":        "maven_repository",
 	"npm_and_yarn": "npm_registry",

--- a/cmd/dependabot/internal/cmd/update_test.go
+++ b/cmd/dependabot/internal/cmd/update_test.go
@@ -204,6 +204,40 @@ func Test_processInput(t *testing.T) {
 
 		assertStringArraysEqual(t, expectedGitCredentalsMetadataHosts, actualCredentialsMetadataHosts)
 	})
+
+	t.Run("add Azure Artifacts credentials for cargo when local token is present", func(t *testing.T) {
+		var input = model.Input{
+			Job: model.Job{
+				PackageManager: "cargo",
+				Source: model.Source{
+					Repo:      "org/project/_git/repo",
+					Directory: "/",
+				},
+			},
+		}
+		var flags = UpdateFlags{
+			apiUrl: "https://dev.azure.com/org/project/_git/repo",
+		}
+		os.Unsetenv("LOCAL_GITHUB_ACCESS_TOKEN")
+		os.Setenv("LOCAL_AZURE_ACCESS_TOKEN", "token")
+
+		processInput(&input, &flags)
+
+		// Ensure cargo_registry credentials are added for Azure Artifacts hosts
+		actualCargoRegistryStrings := []string{}
+		for _, cred := range input.Credentials {
+			if cred["type"] == "cargo_registry" {
+				actualCargoRegistryStrings = append(actualCargoRegistryStrings, fmt.Sprintf("%s|%s", cred["host"], cred["password"]))
+			}
+		}
+
+		expectedCargoRegistries := []string{
+			"org.pkgs.visualstudio.com|$LOCAL_AZURE_ACCESS_TOKEN",
+			"pkgs.dev.azure.com|$LOCAL_AZURE_ACCESS_TOKEN",
+		}
+
+		assertStringArraysEqual(t, expectedCargoRegistries, actualCargoRegistryStrings)
+	})
 }
 
 func assertStringArraysEqual(t *testing.T, expected, actual []string) {


### PR DESCRIPTION
Add `cargo` -> `cargo_registry` to the `azureArtifactsPackageManagerCredentialType` map so that Azure Artifacts credentials are injected for Cargo package manager update jobs.

## Changes
- Added `cargo`: `cargo_registry` entry to the credential type map in `cmd/dependabot/internal/cmd/update.go`
- Added test case verifying Azure Artifacts credentials are generated for cargo