### PR TITLE
Use url and token fields for cargo Azure Artifacts credentials

### DIFF
--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -410,12 +410,21 @@ func processInput(input *model.Input, flags *UpdateFlags) {
 				fmt.Sprintf("%s.pkgs.visualstudio.com", azureRepo.Org),
 			}
 			for _, host := range azureArtifactsHosts {
-				input.Credentials = append(input.Credentials, model.Credential{
-					"type":     azureArtifactsPackageManagerCredentialType[input.Job.PackageManager],
-					"host":     host,
-					"username": "x-access-token",
-					"password": "$LOCAL_AZURE_ACCESS_TOKEN",
-				})
+				credType := azureArtifactsPackageManagerCredentialType[input.Job.PackageManager]
+				if input.Job.PackageManager == "cargo" {
+					input.Credentials = append(input.Credentials, model.Credential{
+						"type":  credType,
+						"url":   fmt.Sprintf("https://%s", host),
+						"token": "$LOCAL_AZURE_ACCESS_TOKEN",
+					})
+				} else {
+					input.Credentials = append(input.Credentials, model.Credential{
+						"type":     credType,
+						"host":     host,
+						"username": "x-access-token",
+						"password": "$LOCAL_AZURE_ACCESS_TOKEN",
+					})
+				}
 			}
 		} else {
 			log.Printf("Skipping Azure Artifacts credentials for %s package manager.", input.Job.PackageManager)

--- a/cmd/dependabot/internal/cmd/update_test.go
+++ b/cmd/dependabot/internal/cmd/update_test.go
@@ -223,17 +223,17 @@ func Test_processInput(t *testing.T) {
 
 		processInput(&input, &flags)
 
-		// Ensure cargo_registry credentials are added for Azure Artifacts hosts
+		// Ensure cargo_registry credentials are added for Azure Artifacts hosts with url and token
 		actualCargoRegistryStrings := []string{}
 		for _, cred := range input.Credentials {
 			if cred["type"] == "cargo_registry" {
-				actualCargoRegistryStrings = append(actualCargoRegistryStrings, fmt.Sprintf("%s|%s", cred["host"], cred["password"]))
+				actualCargoRegistryStrings = append(actualCargoRegistryStrings, fmt.Sprintf("%s|%s", cred["url"], cred["token"]))
 			}
 		}
 
 		expectedCargoRegistries := []string{
-			"org.pkgs.visualstudio.com|$LOCAL_AZURE_ACCESS_TOKEN",
-			"pkgs.dev.azure.com|$LOCAL_AZURE_ACCESS_TOKEN",
+			"https://org.pkgs.visualstudio.com|$LOCAL_AZURE_ACCESS_TOKEN",
+			"https://pkgs.dev.azure.com|$LOCAL_AZURE_ACCESS_TOKEN",
 		}
 
 		assertStringArraysEqual(t, expectedCargoRegistries, actualCargoRegistryStrings)


### PR DESCRIPTION
When the package manager is cargo, Azure Artifacts credentials now use `url` (`https://<host>`) and `token` fields instead of `host`, `username`, and `password`. This matches the expected credential format for cargo registries.

The proxy pulls the `url` value [here](https://github.com/dependabot/proxy/blob/bf13607d24f11c5313dd547916eede60172a1f91/internal/handlers/cargo_registry.go#L57) and the `token` value [here](https://github.com/dependabot/proxy/blob/bf13607d24f11c5313dd547916eede60172a1f91/internal/handlers/cargo_registry.go#L72) so that's what we need to match.