### PR TITLE
add auto-created azure credentials to `job.credentials-metadata`

### DIFF
--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -416,6 +416,10 @@ func processInput(input *model.Input, flags *UpdateFlags) {
 					"username": "x-access-token",
 					"password": "$LOCAL_AZURE_ACCESS_TOKEN",
 				})
+				input.Job.CredentialsMetadata = append(input.Job.CredentialsMetadata, model.Credential{
+					"type": azureArtifactsPackageManagerCredentialType[input.Job.PackageManager],
+					"host": host,
+				})
 			}
 		} else {
 			log.Printf("Skipping Azure Artifacts credentials for %s package manager.", input.Job.PackageManager)


### PR DESCRIPTION
This PR goes along with https://github.com/dependabot/dependabot-core/pull/15298

Ensure that every Azure credentials object that gets auto-added is also added to the `job.credentials-metadata` object.  This ensures the updater knows that credentials exist in the proxy.