### PR TITLE
Accept hyphenated experiment name and limit case-insensitive filesystem to nuget

### DIFF
--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -3,6 +3,7 @@ package model
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -62,8 +63,18 @@ type Job struct {
 }
 
 func (j *Job) UseCaseInsensitiveFileSystem() bool {
-	if experimentValue, isBoolean := j.Experiments["use_case_insensitive_filesystem"].(bool); isBoolean && experimentValue {
-		return true
+	return j.experimentEnabled("use_case_insensitive_filesystem")
+}
+
+// experimentEnabled reports whether the named boolean experiment is enabled.
+// name is the canonical experiment name using underscores; the hyphenated
+// variant is also checked to accommodate both naming conventions.
+func (j *Job) experimentEnabled(name string) bool {
+	hyphenated := strings.ReplaceAll(name, "_", "-")
+	for _, n := range []string{name, hyphenated} {
+		if experimentValue, isBoolean := j.Experiments[n].(bool); isBoolean && experimentValue {
+			return true
+		}
 	}
 
 	return false

--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -63,7 +63,7 @@ type Job struct {
 }
 
 func (j *Job) UseCaseInsensitiveFileSystem() bool {
-	return j.experimentEnabled("use_case_insensitive_filesystem")
+	return j.PackageManager == "nuget" && j.experimentEnabled("use_case_insensitive_filesystem")
 }
 
 // experimentEnabled reports whether the named boolean experiment is enabled.

--- a/internal/model/job_test.go
+++ b/internal/model/job_test.go
@@ -21,6 +21,31 @@ func TestInput(t *testing.T) {
 	compareMap(t, "job", input2["job"], input.Job)
 }
 
+func TestUseCaseInsensitiveFileSystem(t *testing.T) {
+	tests := []struct {
+		name        string
+		experiments Experiment
+		want        bool
+	}{
+		{"nil experiments", nil, false},
+		{"empty experiments", Experiment{}, false},
+		{"underscore true", Experiment{"use_case_insensitive_filesystem": true}, true},
+		{"underscore false", Experiment{"use_case_insensitive_filesystem": false}, false},
+		{"hyphen true", Experiment{"use-case-insensitive-filesystem": true}, true},
+		{"hyphen false", Experiment{"use-case-insensitive-filesystem": false}, false},
+		{"non-bool value", Experiment{"use_case_insensitive_filesystem": "true"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			j := &Job{Experiments: tt.experiments}
+			if got := j.UseCaseInsensitiveFileSystem(); got != tt.want {
+				t.Errorf("UseCaseInsensitiveFileSystem() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAllowedUpdateTypes(t *testing.T) {
 	var input Input
 	if err := yaml.Unmarshal([]byte(exampleJob), &input); err != nil {

--- a/internal/model/job_test.go
+++ b/internal/model/job_test.go
@@ -23,22 +23,26 @@ func TestInput(t *testing.T) {
 
 func TestUseCaseInsensitiveFileSystem(t *testing.T) {
 	tests := []struct {
-		name        string
-		experiments Experiment
-		want        bool
+		name           string
+		packageManager string
+		experiments    Experiment
+		want           bool
 	}{
-		{"nil experiments", nil, false},
-		{"empty experiments", Experiment{}, false},
-		{"underscore true", Experiment{"use_case_insensitive_filesystem": true}, true},
-		{"underscore false", Experiment{"use_case_insensitive_filesystem": false}, false},
-		{"hyphen true", Experiment{"use-case-insensitive-filesystem": true}, true},
-		{"hyphen false", Experiment{"use-case-insensitive-filesystem": false}, false},
-		{"non-bool value", Experiment{"use_case_insensitive_filesystem": "true"}, false},
+		{"nil experiments", "nuget", nil, false},
+		{"empty experiments", "nuget", Experiment{}, false},
+		{"underscore true", "nuget", Experiment{"use_case_insensitive_filesystem": true}, true},
+		{"underscore false", "nuget", Experiment{"use_case_insensitive_filesystem": false}, false},
+		{"hyphen true", "nuget", Experiment{"use-case-insensitive-filesystem": true}, true},
+		{"hyphen false", "nuget", Experiment{"use-case-insensitive-filesystem": false}, false},
+		{"non-bool value", "nuget", Experiment{"use_case_insensitive_filesystem": "true"}, false},
+		{"non-nuget with experiment", "npm_and_yarn", Experiment{"use_case_insensitive_filesystem": true}, false},
+		{"non-nuget hyphen with experiment", "gomod", Experiment{"use-case-insensitive-filesystem": true}, false},
+		{"empty package manager with experiment", "", Experiment{"use_case_insensitive_filesystem": true}, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			j := &Job{Experiments: tt.experiments}
+			j := &Job{PackageManager: tt.packageManager, Experiments: tt.experiments}
 			if got := j.UseCaseInsensitiveFileSystem(); got != tt.want {
 				t.Errorf("UseCaseInsensitiveFileSystem() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
The CLI checks for the experiment flag `use_case_insensitive_filesystem`. This updates `UseCaseInsensitiveFileSystem()` so that it:

- Also accepts the hyphenated variant `use-case-insensitive-filesystem`, via a new `experimentEnabled` helper that takes the canonical underscore name and checks both the underscore and hyphenated forms.
- Only returns `true` when the job's package manager is `nuget`.

Added `TestUseCaseInsensitiveFileSystem` covering both experiment name variants, false/missing/non-bool values, and non-nuget package managers.