### PR TITLE
Modernize Go code

### DIFF
--- a/cmd/dependabot/internal/cmd/update_test.go
+++ b/cmd/dependabot/internal/cmd/update_test.go
@@ -328,7 +328,7 @@ func Test_extractInput(t *testing.T) {
 	t.Run("test server", func(t *testing.T) {
 		go func() {
 			// Retry the calls in case the server takes a bit to start up.
-			for i := 0; i < 10; i++ {
+			for range 10 {
 				body := strings.NewReader(`{"job":{"package-manager":"go_modules"}}`)
 				req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://127.0.0.1:8080", body)
 				if err != nil {

--- a/internal/infra/proxy_test.go
+++ b/internal/infra/proxy_test.go
@@ -9,8 +9,8 @@ import (
 func envValue(env []string, key string) (string, bool) {
 	prefix := key + "="
 	for _, e := range env {
-		if strings.HasPrefix(e, prefix) {
-			return strings.TrimPrefix(e, prefix), true
+		if after, ok := strings.CutPrefix(e, prefix); ok {
+			return after, true
 		}
 	}
 	return "", false

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"maps"
 	"net/http"
 	"os"
 	"os/signal"
@@ -328,9 +329,7 @@ func expandEnvironmentVariables(api *server.API, params *RunParams) {
 		params.Creds = []model.Credential{}
 		for _, cred := range api.Actual.Input.Credentials {
 			newCred := model.Credential{}
-			for k, v := range cred {
-				newCred[k] = v
-			}
+			maps.Copy(newCred, cred)
 			params.Creds = append(params.Creds, newCred)
 		}
 	}
@@ -640,7 +639,7 @@ func pullImageWithAuth(ctx context.Context, cli *client.Client, imageName string
 		username := os.Getenv("AZURE_REGISTRY_USERNAME")
 		password := os.Getenv("AZURE_REGISTRY_PASSWORD")
 
-		registryName := strings.Split(imageName, "/")[0]
+		registryName, _, _ := strings.Cut(imageName, "/")
 
 		if username != "" && password != "" {
 			authConfig := registry.AuthConfig{

--- a/internal/infra/tty.go
+++ b/internal/infra/tty.go
@@ -56,7 +56,7 @@ func initTtySize(ctx context.Context, out *streams.Out, cli *client.Client, id s
 	if err := rttyFunc(ctx, out, cli, id, isExec); err != nil {
 		go func() {
 			var err error
-			for retry := 0; retry < 10; retry++ {
+			for retry := range 10 {
 				time.Sleep(time.Duration(retry+1) * 10 * time.Millisecond)
 				if err = rttyFunc(ctx, out, cli, id, isExec); err == nil {
 					break

--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -110,7 +110,7 @@ type ExistingPRDependency struct {
 
 type ExistingPullRequests []ExistingPR
 
-func (e *ExistingPullRequests) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (e *ExistingPullRequests) UnmarshalYAML(unmarshal func(any) error) error {
 	// First try the new format (array of ExistingPR objects)
 	var newFormat []ExistingPR
 	if err := unmarshal(&newFormat); err == nil {
@@ -185,7 +185,7 @@ func (e ExistingPullRequests) MarshalJSON() ([]byte, error) {
 	return json.Marshal(oldFormat)
 }
 
-func (e ExistingPullRequests) MarshalYAML() (interface{}, error) {
+func (e ExistingPullRequests) MarshalYAML() (any, error) {
 	// Check if this is using the new grouped format (has pr-number or dependencies)
 	hasNewFormat := false
 	for _, pr := range e {

--- a/internal/model/job_test.go
+++ b/internal/model/job_test.go
@@ -446,7 +446,7 @@ job:
 	}
 }
 
-func compareMap(t *testing.T, parent string, expected map[string]any, actual interface{}) {
+func compareMap(t *testing.T, parent string, expected map[string]any, actual any) {
 	actualType := reflect.TypeOf(actual)
 	if actualType.Kind() != reflect.Struct {
 		// Some fields like Experiments are not modeled as structs
@@ -457,7 +457,7 @@ func compareMap(t *testing.T, parent string, expected map[string]any, actual int
 	for key, value := range expected {
 		// Walk the struct and find the field with the yaml tag that matches the map key name.
 		fieldIndex := -1
-		for i := 0; i < fields; i++ {
+		for i := range fields {
 			field := actualType.Field(i)
 			name := yamlTagCleaner(field.Tag.Get("yaml"))
 			if key == name {

--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -92,8 +92,8 @@ type IncrementMetric struct {
 
 type Ecosystem struct {
 	Name           string         `json:"name" yaml:"name"`
-	PackageManager VersionManager `json:"package_manager,omitempty" yaml:"package_manager,omitempty"`
-	Language       VersionManager `json:"language,omitempty" yaml:"language,omitempty"`
+	PackageManager VersionManager `json:"package_manager" yaml:"package_manager,omitempty"`
+	Language       VersionManager `json:"language" yaml:"language,omitempty"`
 }
 
 type VersionManager struct {


### PR DESCRIPTION
## Summary

- apply the Go `modernize` analyzer across production and test packages
- use modern standard-library helpers such as `maps.Copy`, `strings.Cut`, and `strings.CutPrefix`
- adopt integer ranges and `any`, and remove ineffective JSON `omitempty` options from struct-valued fields

## Review notes

The generated changes were reviewed for behavior differences. In particular, removing JSON `omitempty` from `VersionManager` fields does not change serialization because `encoding/json` does not consider non-pointer structs empty. The analyzer skipped `omitzero` alternatives that it identified as possible behavior changes.

## Validation

- `go test -timeout=2m ./cmd/dependabot/internal/cmd ./internal/infra ./internal/model ./internal/server`
- `go vet ./...`
- `go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest ./...`
- `go test -shuffle=on -count=2 -race -cover -timeout=5m ./...` passed all four code packages, but the Docker-backed `cmd/dependabot` script suite exceeded its five-minute package timeout while building and running test containers