### PR TITLE
Support zero day cooldown

### DIFF
--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -146,6 +146,17 @@ func NewUpdateCommand() *cobra.Command {
 }
 
 func extractInput(cmd *cobra.Command, flags *UpdateFlags) (*model.Input, error) {
+	input, err := readInput(cmd, flags)
+	if err != nil {
+		return nil, err
+	}
+	if err := input.Job.UpdateCooldown.Validate(); err != nil {
+		return nil, err
+	}
+	return input, nil
+}
+
+func readInput(cmd *cobra.Command, flags *UpdateFlags) (*model.Input, error) {
 	hasFile := flags.file != ""
 	hasArguments := len(cmd.Flags().Args()) > 0
 	hasServer := flags.inputServerPort != 0

--- a/cmd/dependabot/internal/cmd/update.go
+++ b/cmd/dependabot/internal/cmd/update.go
@@ -146,17 +146,6 @@ func NewUpdateCommand() *cobra.Command {
 }
 
 func extractInput(cmd *cobra.Command, flags *UpdateFlags) (*model.Input, error) {
-	input, err := readInput(cmd, flags)
-	if err != nil {
-		return nil, err
-	}
-	if err := input.Job.UpdateCooldown.Validate(); err != nil {
-		return nil, err
-	}
-	return input, nil
-}
-
-func readInput(cmd *cobra.Command, flags *UpdateFlags) (*model.Input, error) {
 	hasFile := flags.file != ""
 	hasArguments := len(cmd.Flags().Args()) > 0
 	hasServer := flags.inputServerPort != 0

--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -96,6 +96,9 @@ func (p *RunParams) Validate() error {
 	if p.Job.Source.Commit != "" && !gitShaRegex.MatchString(p.Job.Source.Commit) {
 		return fmt.Errorf("commit must be a SHA, or not provided")
 	}
+	if err := p.Job.UpdateCooldown.Validate(); err != nil {
+		return err
+	}
 	// Allows for older smoke tests without the command field to keep working.
 	if p.Job.Command == "" {
 		p.Job.Command = model.UpdateFilesCommand

--- a/internal/infra/run_test.go
+++ b/internal/infra/run_test.go
@@ -49,6 +49,32 @@ func Test_setImageNames(t *testing.T) {
 	})
 }
 
+func Test_RunParamsValidateCooldown(t *testing.T) {
+	days := func(n int) *int { return &n }
+
+	tests := []struct {
+		name     string
+		cooldown *model.UpdateCooldown
+		wantErr  bool
+	}{
+		{"no cooldown", nil, false},
+		{"zero is allowed", &model.UpdateCooldown{DefaultDays: days(0)}, false},
+		{"positive is allowed", &model.UpdateCooldown{DefaultDays: days(7)}, false},
+		{"negative is rejected", &model.UpdateCooldown{DefaultDays: days(-1)}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := &RunParams{
+				Job: &model.Job{PackageManager: "go_modules", UpdateCooldown: tt.cooldown},
+			}
+			if err := params.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %t", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func Test_checkCredAccess(t *testing.T) {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -273,10 +273,32 @@ type CommitOptions struct {
 type Credential map[string]any
 
 type UpdateCooldown struct {
-	DefaultDays     int      `json:"default-days,omitempty" yaml:"default-days,omitempty"`
-	SemverMajorDays int      `json:"semver-major-days,omitempty" yaml:"semver-major-days,omitempty"`
-	SemverMinorDays int      `json:"semver-minor-days,omitempty" yaml:"semver-minor-days,omitempty"`
-	SemverPatchDays int      `json:"semver-patch-days,omitempty" yaml:"semver-patch-days,omitempty"`
+	DefaultDays     *int     `json:"default-days,omitempty" yaml:"default-days,omitempty"`
+	SemverMajorDays *int     `json:"semver-major-days,omitempty" yaml:"semver-major-days,omitempty"`
+	SemverMinorDays *int     `json:"semver-minor-days,omitempty" yaml:"semver-minor-days,omitempty"`
+	SemverPatchDays *int     `json:"semver-patch-days,omitempty" yaml:"semver-patch-days,omitempty"`
 	Include         []string `json:"include,omitempty" yaml:"include,omitempty"`
 	Exclude         []string `json:"exclude,omitempty" yaml:"exclude,omitempty"`
+}
+
+// Validate rejects negative cooldown days. Zero is valid and means no cooldown.
+func (c *UpdateCooldown) Validate() error {
+	if c == nil {
+		return nil
+	}
+	fields := []struct {
+		name string
+		days *int
+	}{
+		{"default-days", c.DefaultDays},
+		{"semver-major-days", c.SemverMajorDays},
+		{"semver-minor-days", c.SemverMinorDays},
+		{"semver-patch-days", c.SemverPatchDays},
+	}
+	for _, field := range fields {
+		if field.days != nil && *field.days < 0 {
+			return fmt.Errorf("cooldown %s must be zero or greater, got %d", field.name, *field.days)
+		}
+	}
+	return nil
 }

--- a/internal/model/job_test.go
+++ b/internal/model/job_test.go
@@ -21,6 +21,157 @@ func TestInput(t *testing.T) {
 	compareMap(t, "job", input2["job"], input.Job)
 }
 
+func TestUpdateCooldownAllowsZero(t *testing.T) {
+	cooldownFields := []string{"default-days", "semver-major-days", "semver-minor-days", "semver-patch-days"}
+
+	tests := []struct {
+		name        string
+		testYAML    string
+		wantPresent bool
+		wantValue   int
+	}{
+		{
+			name: "explicit zero is preserved",
+			testYAML: `---
+job:
+  package-manager: npm_and_yarn
+  source:
+    provider: github
+    repo: dependabot/test
+    directory: "/"
+  cooldown:
+    default-days: 0
+    semver-major-days: 0
+    semver-minor-days: 0
+    semver-patch-days: 0
+`,
+			wantPresent: true,
+			wantValue:   0,
+		},
+		{
+			name: "non-zero is preserved",
+			testYAML: `---
+job:
+  package-manager: npm_and_yarn
+  source:
+    provider: github
+    repo: dependabot/test
+    directory: "/"
+  cooldown:
+    default-days: 3
+    semver-major-days: 3
+    semver-minor-days: 3
+    semver-patch-days: 3
+`,
+			wantPresent: true,
+			wantValue:   3,
+		},
+		{
+			name: "omitted days stay omitted",
+			testYAML: `---
+job:
+  package-manager: npm_and_yarn
+  source:
+    provider: github
+    repo: dependabot/test
+    directory: "/"
+  cooldown:
+    include:
+      - dependency-name-1
+`,
+			wantPresent: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var input Input
+			if err := yaml.Unmarshal([]byte(tt.testYAML), &input); err != nil {
+				t.Fatal(err)
+			}
+
+			data, err := json.Marshal(input.Job)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var payload map[string]any
+			if err := json.Unmarshal(data, &payload); err != nil {
+				t.Fatal(err)
+			}
+			cooldown, ok := payload["cooldown"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected cooldown object, got %v", payload["cooldown"])
+			}
+
+			for _, field := range cooldownFields {
+				value, present := cooldown[field]
+				if present != tt.wantPresent {
+					t.Errorf("cooldown %s present = %t, want %t", field, present, tt.wantPresent)
+					continue
+				}
+				if tt.wantPresent && value != float64(tt.wantValue) {
+					t.Errorf("cooldown %s = %v, want %d", field, value, tt.wantValue)
+				}
+			}
+
+			// Verify round-trip: smoke tests marshal the job back to YAML, which must preserve zero too.
+			out, err := yaml.Marshal(input.Job)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var roundTripped Job
+			if err := yaml.Unmarshal(out, &roundTripped); err != nil {
+				t.Fatal(err)
+			}
+
+			days := map[string]*int{
+				"default-days":      roundTripped.UpdateCooldown.DefaultDays,
+				"semver-major-days": roundTripped.UpdateCooldown.SemverMajorDays,
+				"semver-minor-days": roundTripped.UpdateCooldown.SemverMinorDays,
+				"semver-patch-days": roundTripped.UpdateCooldown.SemverPatchDays,
+			}
+			for field, got := range days {
+				if (got != nil) != tt.wantPresent {
+					t.Errorf("round-trip: cooldown %s set = %t, want %t", field, got != nil, tt.wantPresent)
+					continue
+				}
+				if tt.wantPresent && *got != tt.wantValue {
+					t.Errorf("round-trip: cooldown %s = %d, want %d", field, *got, tt.wantValue)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateCooldownValidate(t *testing.T) {
+	days := func(n int) *int { return &n }
+
+	tests := []struct {
+		name     string
+		cooldown *UpdateCooldown
+		wantErr  bool
+	}{
+		{"nil cooldown", nil, false},
+		{"no days set", &UpdateCooldown{Include: []string{"a"}}, false},
+		{"zero is allowed", &UpdateCooldown{DefaultDays: days(0)}, false},
+		{"positive is allowed", &UpdateCooldown{DefaultDays: days(7)}, false},
+		{"negative default", &UpdateCooldown{DefaultDays: days(-1)}, true},
+		{"negative semver-major", &UpdateCooldown{SemverMajorDays: days(-1)}, true},
+		{"negative semver-minor", &UpdateCooldown{SemverMinorDays: days(-1)}, true},
+		{"negative semver-patch", &UpdateCooldown{SemverPatchDays: days(-1)}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cooldown.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %t", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestUseCaseInsensitiveFileSystem(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/testdata/cooldown.yml
+++ b/testdata/cooldown.yml
@@ -1,0 +1,19 @@
+job:
+  package-manager: go_modules
+  allowed-updates:
+    - dependency-type: direct
+      update-type: all
+  source:
+    provider: github
+    repo: dependabot/cli
+    directory: /
+  cooldown:
+    default-days: 0
+    semver-major-days: 0
+    semver-minor-days: 0
+    semver-patch-days: 0
+credentials:
+  - type: git_source
+    host: github.com
+    username: x-access-token
+    password: $LOCAL_GITHUB_ACCESS_TOKEN


### PR DESCRIPTION
Cooldown day values of `0` were silently dropped from the job payload. The fields were `int` with `omitempty`, so `0` was indistinguishable from unset:

```
before: {"cooldown":{}}
after:  {"cooldown":{"default-days":0,...}}
```

This makes `0` a usable way to explicitly disable cooldown.

### Changes
- `UpdateCooldown` day fields are now `*int` — explicit `0` serializes, unset stays omitted.
- Added `UpdateCooldown.Validate()` in `extractInput` to reject negative values, covering all input paths (file, args, server, stdin) for `update` and `graph`.
- Tests for zero / non-zero / omitted across the JSON and YAML round-trips.

`omitempty` is retained per the model-versioning guidance in `internal/model/job.go`, so this stays compatible with dependabot-core before and after. No existing smoke tests set a zero cooldown.