### PR TITLE
allow new commands unknown to the CLI

### DIFF
--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -39,6 +39,13 @@ var runCmds = map[model.RunCommand]string{
 	model.UpdateGraphCommand: "bin/run fetch_files && bin/run update_graph",
 }
 
+func updaterCommand(command model.RunCommand) string {
+	if cmd, ok := runCmds[command]; ok {
+		return cmd
+	}
+	return "bin/run"
+}
+
 type RunParams struct {
 	// Input file
 	Input string
@@ -482,7 +489,7 @@ func runContainers(ctx context.Context, params RunParams) (err error) {
 		if params.Flamegraph {
 			env = append(env, "FLAMEGRAPH=1")
 		}
-		if err := updater.RunCmd(ctx, runCmds[params.Job.Command], dependabot, env...); err != nil {
+		if err := updater.RunCmd(ctx, updaterCommand(params.Job.Command), dependabot, env...); err != nil {
 			return err
 		}
 		if params.Flamegraph {

--- a/internal/infra/run_test.go
+++ b/internal/infra/run_test.go
@@ -246,3 +246,23 @@ func Test_generateIgnoreConditions(t *testing.T) {
 		}
 	})
 }
+
+func Test_updaterCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		command  model.RunCommand
+		expected string
+	}{
+		{"update", model.UpdateFilesCommand, "bin/run fetch_files && bin/run update_files"},
+		{"graph", model.UpdateGraphCommand, "bin/run fetch_files && bin/run update_graph"},
+		{"unmapped command falls through to a bare bin/run", "reachability", "bin/run"},
+		{"unrecognized command is never a no-op", "not-a-real-command", "bin/run"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := updaterCommand(tt.command); got != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Rather than having to keep list of known commands, this allows anyone to author a `job.json` with a custom command given a custom updater-image and it will run `bin/run` assuming the image knows what to do.