### PR TITLE
Document that brew distribution supports Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Use any of the following for a pain-free installation:
    ```
    The benefit of this method is that re-running the command will always update to the latest version.
 * You can download a pre-built binary from the [releases] page.
-* On Mac, you can run `brew install dependabot`
+* On Mac or Linux, you can run `brew install dependabot`
 
 ## Requirements
 


### PR DESCRIPTION
```
yeikel@local:~$ brew install dependabot
==> Downloading Homebrew API data
✔︎ JSON API packages.x86_64_linux.jws.json                                                   Downloaded   15.5MB/ 15.5MB
==> Downloading bottle manifests
✔︎ Bottle Manifest dependabot (1.92.0)                                                       Downloaded   14.9KB/ 14.9KB
==> Would install 1 formula:
dependabot
==> Fetching downloads for: dependabot
✔︎ Bottle dependabot (1.92.0)                                                                Downloaded    4.0MB/  4.0MB
==> Pouring dependabot--1.92.0.x86_64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/dependabot/1.92.0: 10 files, 9.9MB
==> Running `brew cleanup dependabot`...
Disable this behaviour by setting `HOMEBREW_NO_INSTALL_CLEANUP=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
==> Caveats
Bash completion has been installed to:
  /home/linuxbrew/.linuxbrew/etc/bash_completion.d
yeikel@local:~$ dependabot
Run Dependabot jobs from the command line.
```