### PR TITLE
allow unknown endpoints to pass through

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -137,12 +137,6 @@ func (a *API) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		updatePR.UpdatedDependencyFiles = replaceBinaryWithHash(updatePR.UpdatedDependencyFiles)
 	}
 
-	if actual == nil {
-		// indicates the kind (endpoint) isn't implemented in decodeWrapper, so return a 501
-		w.WriteHeader(http.StatusNotImplemented)
-		return
-	}
-
 	if kind == "increment_metric" || kind == "record_ecosystem_meta" {
 		// These calls are noisy and changeable; skip recording them in output
 		return
@@ -251,7 +245,9 @@ func decodeWrapper(kind string, data []byte) (actual *model.UpdateWrapper, err e
 	case "increment_metric":
 		actual.Data, err = decode[model.IncrementMetric](data)
 	default:
-		return nil, fmt.Errorf("unexpected output type: %s", kind)
+		// An endpoint the CLI has no model for is still reported to stdout so a
+		// new API endpoint can be exercised before the CLI knows its shape.
+		actual.Data, err = decode[map[string]any](data)
 	}
 	return actual, err
 }

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -25,15 +25,28 @@ func Test_decodeWrapper(t *testing.T) {
 }
 
 func TestAPI_ServeHTTP(t *testing.T) {
-	t.Run("doesn't crash when unknown endpoint is used", func(t *testing.T) {
-		request := httptest.NewRequest("POST", "/unexpected-endpoint", nil)
+	t.Run("records unknown endpoints instead of rejecting them", func(t *testing.T) {
+		var stdout bytes.Buffer
+		body := `{"data":{"commitSha":"abc123"}}`
+		request := httptest.NewRequest("POST", "/update_jobs/1/unexpected-endpoint", bytes.NewBufferString(body))
 		response := httptest.NewRecorder()
 
-		api := NewAPI(nil, nil)
+		api := NewAPI(nil, &stdout)
+		defer api.Stop()
 		api.ServeHTTP(response, request)
 
-		if response.Code != http.StatusNotImplemented {
-			t.Errorf("expected status code %d, got %d", http.StatusNotImplemented, response.Code)
+		if response.Code != http.StatusOK {
+			t.Errorf("expected status code %d, got %d", http.StatusOK, response.Code)
+		}
+		if len(api.Errors) != 0 {
+			t.Errorf("expected no errors, got %v", api.Errors)
+		}
+		var recorded Wrapper[map[string]any]
+		if err := json.Unmarshal(stdout.Bytes(), &recorded); err != nil {
+			t.Fatal(err)
+		}
+		if recorded.Data["commitSha"] != "abc123" {
+			t.Errorf("expected the payload on stdout, got %v", recorded.Data)
 		}
 	})
 }


### PR DESCRIPTION
It doesn't seem necessary for us to model every message, so this allows for unknown messages to flow through stdout.

You'll still need to model it to get it into smoke tests for now, but maybe in the future we can allow that too (assuming JSON shaped payloads)