### PR TITLE
Add PowerShell package manager mapping

### DIFF
--- a/internal/infra/run.go
+++ b/internal/infra/run.go
@@ -304,6 +304,7 @@ var packageManagerLookup = map[string]string{
 	"opentofu":       "opentofu",
 	"pip":            "pip",
 	"pre_commit":     "pre-commit",
+	"powershell":     "powershell",
 	"pub":            "pub",
 	"rust_toolchain": "rust-toolchain",
 	"sbt":            "sbt",

--- a/internal/infra/run_test.go
+++ b/internal/infra/run_test.go
@@ -23,6 +23,7 @@ func Test_setImageNames(t *testing.T) {
 	}{
 		{"conda", "conda"},
 		{"deno", "deno"},
+		{"powershell", "powershell"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.packageManager, func(t *testing.T) {


### PR DESCRIPTION
PowerShell smoke tests can now resolve the conventional PowerShell updater image without requiring an explicit `--updater-image` override.

## Changes

- Map `package-manager: powershell` to `ghcr.io/dependabot/dependabot-updater-powershell`.
- Cover the generated updater image name in `Test_setImageNames`.

`record_ecosystem_meta` remains intentionally excluded from smoke-test recordings and expectations, consistent with dependabot/cli#587. This focused registration change does not alter that global contract.

## Related work

- Depends on dependabot/dependabot-core#15666 for the official PowerShell updater image.
- Unblocks dependabot/smoke-tests#569 once this change is released.
- A CLI release is required because the official smoke workflows install `github.com/dependabot/cli/cmd/dependabot@latest`.

## Testing

- `go test ./internal/infra -run '^Test_setImageNames$/powershell$' -count=1`
- `go test -shuffle=on -count=2 -cover -timeout=5m ./cmd/dependabot/internal/cmd ./internal/...`
- `go build -v ./...`
- `go mod tidy -diff`
- `go vet ./...`
- `gofmt -l .`
- Upstream `build` and `lint` checks pass, including the Linux race-enabled suite.
- Focused code review found no issues.

## CI note

The smoke matrix passed 100 jobs. The unrelated `python-pip-compile` job has expectation drift with only 97/130 cached calls; this mapping does not touch Python or smoke expectations.